### PR TITLE
feat: use absolute point category counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,8 @@
     .wrap { display: flex; gap: .5rem; align-items: center; }
     .stack { display: flex; flex-direction: column; gap: .4rem; }
     .tag { min-width: 64px; font-size: .75rem; letter-spacing: .02em; text-transform: uppercase; opacity: .7; }
-    input[type=range] { flex: 1; width: 100%; }
+    input[type=range],
+    input[type=number] { flex: 1; width: 100%; }
     .val { min-width: 66px; text-align: right; font-variant-numeric: tabular-nums; }
     select { flex: 1; }
     #bar { position: absolute; top: 10px; left: 10px; z-index: 12; display: flex; gap: 8px; }
@@ -244,9 +245,9 @@
     </button>
     <div class="accordion__panel" id="acc-points-panel" role="region" aria-labelledby="acc-points-trigger">
       <div class="row">
-        <label for="pCount">Anzahl Punkte</label>
+        <label for="pCount">Anzahl Punkte (Summe)</label>
         <div class="wrap">
-          <input id="pCount" type="range" min="500" max="8000" step="100" />
+          <input id="pCount" type="number" min="0" step="1" readonly />
           <div class="val" id="vCount"></div>
         </div>
       </div>
@@ -301,22 +302,22 @@
         </div>
       </div>
       <div class="row">
-        <label>Punktkategorien (%)</label>
+        <label>Punktkategorien (Anzahl)</label>
         <div class="stack">
           <div class="wrap">
             <span class="tag">Klein</span>
-            <input id="pCatSmall" type="range" min="0" max="100" step="1" />
-            <div class="val" id="vCatSmall"></div>
+            <input id="pCatSmallCount" type="number" min="0" step="1" />
+            <div class="val" id="vCatSmallCount"></div>
           </div>
           <div class="wrap">
             <span class="tag">Mittel</span>
-            <input id="pCatMedium" type="range" min="0" max="100" step="1" />
-            <div class="val" id="vCatMedium"></div>
+            <input id="pCatMediumCount" type="number" min="0" step="1" />
+            <div class="val" id="vCatMediumCount"></div>
           </div>
           <div class="wrap">
             <span class="tag">Groß</span>
-            <input id="pCatLarge" type="range" min="0" max="100" step="1" />
-            <div class="val" id="vCatLarge"></div>
+            <input id="pCatLargeCount" type="number" min="0" step="1" />
+            <div class="val" id="vCatLargeCount"></div>
           </div>
         </div>
       </div>
@@ -502,9 +503,9 @@ const params = {
   pointAlpha: 0.95,
   pointHue: 210,
   seedStars: 1,
-  catSmall: 45,
-  catMedium: 35,
-  catLarge: 20,
+  catSmallCount: 1125,
+  catMediumCount: 875,
+  catLargeCount: 500,
   // Size factors
   sizeFactorTiny: 0.15,
   sizeFactorSmall: 1.0,
@@ -550,14 +551,18 @@ function makeStars() {
     starMaterial.dispose();
     clusterGroup.remove(starPoints);
   }
+  const smallCount = Math.max(0, Math.floor(Number(params.catSmallCount) || 0));
+  const mediumCount = Math.max(0, Math.floor(Number(params.catMediumCount) || 0));
+  const largeCount = Math.max(0, Math.floor(Number(params.catLargeCount) || 0));
+  const total = Math.max(0, smallCount + mediumCount + largeCount);
+  params.count = total;
   starGeometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(params.count * 3);
-  const sizes = new Float32Array(params.count);
-  const cats  = new Float32Array(params.count);
-  // thresholds for categories based on manual percentages
-  const smallShare = Math.max(0, Math.min(1, params.catSmall / 100));
-  const mediumShare = Math.max(0, Math.min(1, params.catMedium / 100));
-  const smallThreshold = smallShare;
+  const positions = new Float32Array(total * 3);
+  const sizes = new Float32Array(total);
+  const cats  = new Float32Array(total);
+  // thresholds for categories based on counts
+  const smallShare = total > 0 ? smallCount / total : 0;
+  const mediumShare = total > 0 ? mediumCount / total : 0;
   const mediumThreshold = Math.min(1, smallShare + mediumShare);
   const minSize = Math.max(0.05, 1 - params.sizeVar * 0.5);
   const maxSize = 1 + params.sizeVar * 0.5;
@@ -566,14 +571,25 @@ function makeStars() {
   const mediumEnd = minSize + span * mediumThreshold;
   // seeded random for star distribution
   const rand = mulberry32(params.seedStars);
+  const catRand = mulberry32(params.seedStars + 0x9e3779b9);
+  const categoryPool = [];
+  for (let i = 0; i < smallCount; i++) categoryPool.push(0);
+  for (let i = 0; i < mediumCount; i++) categoryPool.push(1);
+  for (let i = 0; i < largeCount; i++) categoryPool.push(2);
+  for (let i = categoryPool.length - 1; i > 0; i--) {
+    const j = Math.floor(catRand() * (i + 1));
+    const tmp = categoryPool[i];
+    categoryPool[i] = categoryPool[j];
+    categoryPool[j] = tmp;
+  }
   const orientation = new THREE.Matrix4();
   const orientEuler = new THREE.Euler(rand() * Math.PI * 2, rand() * Math.PI * 2, rand() * Math.PI * 2);
   orientation.makeRotationFromEuler(orientEuler);
   const tmpVec = new THREE.Vector3();
-  const fibOffset = params.distribution === 'fibonacci' ? (2 / params.count) : 0;
+  const fibOffset = (params.distribution === 'fibonacci' && total > 0) ? (2 / total) : 0;
   const fibIncrement = Math.PI * (3 - Math.sqrt(5));
   const spiralArms = 4;
-  for (let i = 0; i < params.count; i++) {
+  for (let i = 0; i < total; i++) {
     let x = 0, y = 0, z = 0;
     const radius = params.radius;
     if (params.distribution === 'fibonacci') {
@@ -592,7 +608,7 @@ function makeStars() {
       tmpVec.set(x, y, z).applyMatrix4(orientation);
       x = tmpVec.x; y = tmpVec.y; z = tmpVec.z;
     } else if (params.distribution === 'spiral') {
-      const t = i / params.count;
+      const t = total > 0 ? (i / total) : 0;
       const arm = i % spiralArms;
       const baseAngle = t * Math.PI * 6 + arm * (Math.PI * 2 / spiralArms);
       const spread = radius * Math.pow(rand(), 0.55 + params.cluster * 0.9);
@@ -618,13 +634,7 @@ function makeStars() {
       z = r * Math.cos(phi);
     }
     positions.set([x, y, z], i * 3);
-    const catSeed = rand();
-    let cat = 2;
-    if (catSeed < smallThreshold) {
-      cat = 0;
-    } else if (catSeed < mediumThreshold) {
-      cat = 1;
-    }
+    const cat = categoryPool[i] !== undefined ? categoryPool[i] : 2;
     cats[i] = cat;
     let lower = mediumEnd;
     let upper = maxSize;
@@ -737,20 +747,22 @@ function makeTiny() {
   const positions = new Float32Array(Math.max(0, nTiny * 3));
   // Access star positions for connections
   const starPos = starGeometry.getAttribute('position');
-  const nStars = starPos.count;
-  const rand = mulberry32(params.seedTiny);
-  for (let i = 0; i < nTiny; i++) {
-    // pick two random stars
-    const idxA = Math.floor(rand() * nStars);
-    const idxB = Math.floor(rand() * nStars);
-    const ax = starPos.getX(idxA), ay = starPos.getY(idxA), az = starPos.getZ(idxA);
-    const bx = starPos.getX(idxB), by = starPos.getY(idxB), bz = starPos.getZ(idxB);
-    const t = rand();
-    // linear interpolation between stars
-    const x = ax + (bx - ax) * t;
-    const y = ay + (by - ay) * t;
-    const z = az + (bz - az) * t;
-    positions.set([x, y, z], i * 3);
+  const nStars = starPos ? starPos.count : 0;
+  if (starPos && nStars > 0) {
+    const rand = mulberry32(params.seedTiny);
+    for (let i = 0; i < nTiny; i++) {
+      // pick two random stars
+      const idxA = Math.floor(rand() * nStars);
+      const idxB = Math.floor(rand() * nStars);
+      const ax = starPos.getX(idxA), ay = starPos.getY(idxA), az = starPos.getZ(idxA);
+      const bx = starPos.getX(idxB), by = starPos.getY(idxB), bz = starPos.getZ(idxB);
+      const t = rand();
+      // linear interpolation between stars
+      const x = ax + (bx - ax) * t;
+      const y = ay + (by - ay) * t;
+      const z = az + (bz - az) * t;
+      positions.set([x, y, z], i * 3);
+    }
   }
   tinyGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   const tinyVert = `
@@ -1276,54 +1288,16 @@ if (spinDecaySlider) {
   });
 }
 
-function setCategoryPercent(kind, value) {
-  const keyMap = { small: 'catSmall', medium: 'catMedium', large: 'catLarge' };
+function setCategoryCount(kind, value) {
+  const keyMap = { small: 'catSmallCount', medium: 'catMediumCount', large: 'catLargeCount' };
   const key = keyMap[kind];
   if (!key) return;
-  const allKeys = ['catSmall', 'catMedium', 'catLarge'];
-  value = Math.max(0, Math.min(100, Math.round(value)));
-  params[key] = value;
-  const otherKeys = allKeys.filter(k => k !== key);
-  let remainder = 100 - params[key];
-  if (remainder < 0) {
-    params[key] = 100;
-    remainder = 0;
+  const next = Math.max(0, Math.floor(Number(value) || 0));
+  if (params[key] === next) {
+    return;
   }
-  const sumOthers = otherKeys.reduce((sum, k) => sum + params[k], 0);
-  if (otherKeys.length) {
-    if (sumOthers === 0) {
-      const even = remainder / otherKeys.length;
-      let acc = 0;
-      otherKeys.forEach((k, idx) => {
-        const val = (idx === otherKeys.length - 1) ? remainder - acc : Math.round(even);
-        params[k] = Math.max(0, Math.min(100, val));
-        acc += params[k];
-      });
-    } else {
-      let acc = 0;
-      otherKeys.forEach((k, idx) => {
-        const ratio = params[k] / sumOthers;
-        const scaled = remainder * ratio;
-        if (idx === otherKeys.length - 1) {
-          params[k] = Math.max(0, Math.min(100, Math.round(remainder - acc)));
-        } else {
-          const rounded = Math.round(scaled);
-          params[k] = Math.max(0, Math.min(100, rounded));
-          acc += params[k];
-        }
-      });
-    }
-  }
-  const total = allKeys.reduce((sum, k) => sum + params[k], 0);
-  let diff = 100 - total;
-  let idx = 0;
-  const adjustOrder = otherKeys.length ? otherKeys : [key];
-  while (diff !== 0 && idx < 300) {
-    const adjustKey = adjustOrder[idx % adjustOrder.length];
-    params[adjustKey] = Math.max(0, Math.min(100, params[adjustKey] + Math.sign(diff)));
-    diff -= Math.sign(diff);
-    idx++;
-  }
+  params[key] = next;
+  rebuildStars();
 }
 
 function getSizeRange() {
@@ -1333,16 +1307,15 @@ function getSizeRange() {
 }
 
 const sliders = {
-  pCount:       val => { params.count = parseInt(val, 10); rebuildStars(); },
   pRadius:      val => { params.radius = parseFloat(val); rebuildStars(); },
   pSizeVar:     val => { params.sizeVar = parseFloat(val); rebuildStars(); },
   pCluster:     val => { params.cluster = parseFloat(val); rebuildStars(); },
   pPointAlpha:  val => { params.pointAlpha = parseFloat(val); updateStarUniforms(); },
   pHue:         val => { params.pointHue = parseFloat(val); updatePointColor(); updateStarUniforms(); updateTinyMaterial(); },
   pSeedStars:   val => { params.seedStars = parseInt(val, 10); rebuildStars(); },
-  pCatSmall:    val => { setCategoryPercent('small', parseInt(val, 10)); rebuildStars(); },
-  pCatMedium:   val => { setCategoryPercent('medium', parseInt(val, 10)); rebuildStars(); },
-  pCatLarge:    val => { setCategoryPercent('large', parseInt(val, 10)); rebuildStars(); },
+  pCatSmallCount:  val => { setCategoryCount('small', val); },
+  pCatMediumCount: val => { setCategoryCount('medium', val); },
+  pCatLargeCount:  val => { setCategoryCount('large', val); },
   pSizeTiny:    val => { params.sizeFactorTiny = parseFloat(val); updateTinyMaterial(); },
   pSizeSmall:   val => { params.sizeFactorSmall = parseFloat(val); updateStarUniforms(); },
   pSizeMedium:  val => { params.sizeFactorMedium = parseFloat(val); updateStarUniforms(); },
@@ -1437,7 +1410,8 @@ lockBtn.addEventListener('click', () => {
 
 $('random').addEventListener('click', () => {
   // randomize many parameters
-  params.count = 500 + Math.floor(Math.random() * 7500);
+  const totalCount = 500 + Math.floor(Math.random() * 7500);
+  params.count = totalCount;
   params.radius = 60 + Math.random() * 180;
   params.sizeVar = Math.random() * 9.5;
   params.cluster = Math.random() * 0.95;
@@ -1446,11 +1420,22 @@ $('random').addEventListener('click', () => {
   params.seedStars = 1 + Math.floor(Math.random() * 9999);
   const distributions = ['random', 'fibonacci', 'spiral'];
   params.distribution = distributions[Math.floor(Math.random() * distributions.length)];
-  const smallShare = Math.floor(Math.random() * 70);
-  const mediumShare = Math.floor(Math.random() * (100 - smallShare));
-  params.catSmall = smallShare;
-  params.catMedium = mediumShare;
-  params.catLarge = 100 - params.catSmall - params.catMedium;
+  const weights = [Math.random(), Math.random(), Math.random()];
+  const weightSum = weights.reduce((sum, value) => sum + value, 0) || 1;
+  const provisional = weights.map(value => Math.max(0, Math.floor((value / weightSum) * totalCount)));
+  let assigned = provisional.reduce((sum, value) => sum + value, 0);
+  let diff = totalCount - assigned;
+  let idx = 0;
+  const adjustOrder = [0, 1, 2];
+  while (diff > 0 && idx < 300) {
+    const target = adjustOrder[idx % adjustOrder.length];
+    provisional[target] += 1;
+    diff -= 1;
+    idx += 1;
+  }
+  params.catSmallCount = provisional[0];
+  params.catMediumCount = provisional[1];
+  params.catLargeCount = Math.max(0, totalCount - params.catSmallCount - params.catMediumCount);
   params.sizeFactorSmall = 0.5 + Math.random() * 2.5;
   params.sizeFactorMedium = 0.5 + Math.random() * 2.5;
   params.sizeFactorLarge = 0.5 + Math.random() * 2.5;
@@ -1470,7 +1455,10 @@ $('random').addEventListener('click', () => {
 /* Update slider displays */
 function setSliders() {
   // star params
-  $('pCount').value = params.count; $('vCount').textContent = params.count;
+  if ($('pCount')) {
+    $('pCount').value = params.count;
+  }
+  $('vCount').textContent = params.count;
   $('pRadius').value = params.radius; $('vRadius').textContent = params.radius;
   $('pDistribution').value = params.distribution;
   $('pSizeVar').value = params.sizeVar;
@@ -1480,9 +1468,9 @@ function setSliders() {
   $('pPointAlpha').value = params.pointAlpha; $('vPointAlpha').textContent = params.pointAlpha.toFixed(2);
   $('pHue').value = params.pointHue; $('vHue').textContent = Math.round(params.pointHue) + '°';
   $('pSeedStars').value = params.seedStars; $('vSeedStars').textContent = params.seedStars;
-  $('pCatSmall').value = params.catSmall; $('vCatSmall').textContent = params.catSmall + '%';
-  $('pCatMedium').value = params.catMedium; $('vCatMedium').textContent = params.catMedium + '%';
-  $('pCatLarge').value = params.catLarge; $('vCatLarge').textContent = params.catLarge + '%';
+  $('pCatSmallCount').value = params.catSmallCount; $('vCatSmallCount').textContent = params.catSmallCount;
+  $('pCatMediumCount').value = params.catMediumCount; $('vCatMediumCount').textContent = params.catMediumCount;
+  $('pCatLargeCount').value = params.catLargeCount; $('vCatLargeCount').textContent = params.catLargeCount;
   // size factors
   $('pSizeTiny').value = params.sizeFactorTiny; $('vSizeTiny').textContent = params.sizeFactorTiny.toFixed(2);
   $('pSizeSmall').value = params.sizeFactorSmall; $('vSizeSmall').textContent = params.sizeFactorSmall.toFixed(2);


### PR DESCRIPTION
## Summary
- replace the Punktkategorien percentage sliders with number inputs for per-size counts and show the derived total
- recompute the star geometry using summed category counts and clamp updates through new setters
- refresh random presets, slider display logic, and tiny-connection handling for zero-count scenarios

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df861f56888324b2c1b05ffcc7217d