### PR TITLE
Add numeric bounds controls for sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,21 @@
       opacity: 0.55;
       cursor: default;
     }
-    .wrap { display: flex; gap: .5rem; align-items: center; }
+    .wrap { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+    .bound-input {
+      width: 64px;
+      padding: .25rem .35rem;
+      font-size: .75rem;
+      color: var(--fg);
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 6px;
+      flex: 0 0 64px;
+    }
+    .bound-input:focus-visible {
+      outline: 2px solid rgba(90, 190, 255, 0.9);
+      outline-offset: 1px;
+    }
     .stack { display: flex; flex-direction: column; gap: .4rem; }
     .tag { min-width: 64px; font-size: .75rem; letter-spacing: .02em; text-transform: uppercase; opacity: .7; }
     input[type=range] { flex: 1; width: 100%; }
@@ -246,14 +260,18 @@
       <div class="row">
         <label for="pCount">Anzahl Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pCount" data-bound="min" />
           <input id="pCount" type="range" min="500" max="8000" step="100" />
+          <input class="bound-input" type="number" data-target="pCount" data-bound="max" />
           <div class="val" id="vCount"></div>
         </div>
       </div>
       <div class="row">
         <label for="pRadius">Radius</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pRadius" data-bound="min" />
           <input id="pRadius" type="range" min="40" max="260" step="1" />
+          <input class="bound-input" type="number" data-target="pRadius" data-bound="max" />
           <div class="val" id="vRadius"></div>
         </div>
       </div>
@@ -268,35 +286,45 @@
       <div class="row">
         <label for="pSizeVar">Größenvariation (Δ)</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSizeVar" data-bound="min" />
           <input id="pSizeVar" type="range" min="0" max="10" step="0.1" />
+          <input class="bound-input" type="number" data-target="pSizeVar" data-bound="max" />
           <div class="val" id="vSizeVar"></div>
         </div>
       </div>
       <div class="row">
         <label for="pCluster">Clustering</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pCluster" data-bound="min" />
           <input id="pCluster" type="range" min="0" max="1" step="0.01" />
+          <input class="bound-input" type="number" data-target="pCluster" data-bound="max" />
           <div class="val" id="vCluster"></div>
         </div>
       </div>
       <div class="row">
         <label for="pPointAlpha">Deckkraft Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pPointAlpha" data-bound="min" />
           <input id="pPointAlpha" type="range" min="0.3" max="1" step="0.01" />
+          <input class="bound-input" type="number" data-target="pPointAlpha" data-bound="max" />
           <div class="val" id="vPointAlpha"></div>
         </div>
       </div>
       <div class="row">
         <label for="pHue">Punktfarbe (Farbton)</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pHue" data-bound="min" />
           <input id="pHue" type="range" min="0" max="360" step="1" />
+          <input class="bound-input" type="number" data-target="pHue" data-bound="max" />
           <div class="val" id="vHue"></div>
         </div>
       </div>
       <div class="row">
         <label for="pSeedStars">Seed Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSeedStars" data-bound="min" />
           <input id="pSeedStars" type="range" min="1" max="9999" step="1" />
+          <input class="bound-input" type="number" data-target="pSeedStars" data-bound="max" />
           <div class="val" id="vSeedStars"></div>
         </div>
       </div>
@@ -305,17 +333,23 @@
         <div class="stack">
           <div class="wrap">
             <span class="tag">Klein</span>
+            <input class="bound-input" type="number" data-target="pCatSmall" data-bound="min" />
             <input id="pCatSmall" type="range" min="0" max="100" step="1" />
+            <input class="bound-input" type="number" data-target="pCatSmall" data-bound="max" />
             <div class="val" id="vCatSmall"></div>
           </div>
           <div class="wrap">
             <span class="tag">Mittel</span>
+            <input class="bound-input" type="number" data-target="pCatMedium" data-bound="min" />
             <input id="pCatMedium" type="range" min="0" max="100" step="1" />
+            <input class="bound-input" type="number" data-target="pCatMedium" data-bound="max" />
             <div class="val" id="vCatMedium"></div>
           </div>
           <div class="wrap">
             <span class="tag">Groß</span>
+            <input class="bound-input" type="number" data-target="pCatLarge" data-bound="min" />
             <input id="pCatLarge" type="range" min="0" max="100" step="1" />
+            <input class="bound-input" type="number" data-target="pCatLarge" data-bound="max" />
             <div class="val" id="vCatLarge"></div>
           </div>
         </div>
@@ -330,28 +364,36 @@
       <div class="row">
         <label for="pSizeTiny">Größe winzige Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSizeTiny" data-bound="min" />
           <input id="pSizeTiny" type="range" min="0.05" max="3" step="0.01" />
+          <input class="bound-input" type="number" data-target="pSizeTiny" data-bound="max" />
           <div class="val" id="vSizeTiny"></div>
         </div>
       </div>
       <div class="row">
         <label for="pSizeSmall">Größe kleine Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSizeSmall" data-bound="min" />
           <input id="pSizeSmall" type="range" min="0.2" max="3" step="0.05" />
+          <input class="bound-input" type="number" data-target="pSizeSmall" data-bound="max" />
           <div class="val" id="vSizeSmall"></div>
         </div>
       </div>
       <div class="row">
         <label for="pSizeMedium">Größe mittlere Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSizeMedium" data-bound="min" />
           <input id="pSizeMedium" type="range" min="0.2" max="3" step="0.05" />
+          <input class="bound-input" type="number" data-target="pSizeMedium" data-bound="max" />
           <div class="val" id="vSizeMedium"></div>
         </div>
       </div>
       <div class="row">
         <label for="pSizeLarge">Größe große Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSizeLarge" data-bound="min" />
           <input id="pSizeLarge" type="range" min="0.2" max="3" step="0.05" />
+          <input class="bound-input" type="number" data-target="pSizeLarge" data-bound="max" />
           <div class="val" id="vSizeLarge"></div>
         </div>
       </div>
@@ -365,28 +407,36 @@
       <div class="row">
         <label for="pTinyCount">Menge winzige Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pTinyCount" data-bound="min" />
           <input id="pTinyCount" type="range" min="0" max="5000" step="10" />
+          <input class="bound-input" type="number" data-target="pTinyCount" data-bound="max" />
           <div class="val" id="vTinyCount"></div>
         </div>
       </div>
       <div class="row">
         <label for="pConnPercent">Prozent Verbindungen</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pConnPercent" data-bound="min" />
           <input id="pConnPercent" type="range" min="0" max="1" step="0.01" />
+          <input class="bound-input" type="number" data-target="pConnPercent" data-bound="max" />
           <div class="val" id="vConnPercent"></div>
         </div>
       </div>
       <div class="row">
         <label for="pTinyAlpha">Deckkraft winzige Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pTinyAlpha" data-bound="min" />
           <input id="pTinyAlpha" type="range" min="0" max="1" step="0.01" />
+          <input class="bound-input" type="number" data-target="pTinyAlpha" data-bound="max" />
           <div class="val" id="vTinyAlpha"></div>
         </div>
       </div>
       <div class="row">
         <label for="pSeedTiny">Seed winzige Punkte</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pSeedTiny" data-bound="min" />
           <input id="pSeedTiny" type="range" min="1" max="9999" step="1" />
+          <input class="bound-input" type="number" data-target="pSeedTiny" data-bound="max" />
           <div class="val" id="vSeedTiny"></div>
         </div>
       </div>
@@ -400,7 +450,9 @@
       <div class="row">
         <label for="pEdgeSoft">Randweichheit</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="pEdgeSoft" data-bound="min" />
           <input id="pEdgeSoft" type="range" min="0" max="1" step="0.01" />
+          <input class="bound-input" type="number" data-target="pEdgeSoft" data-bound="max" />
           <div class="val" id="vEdgeSoft"></div>
         </div>
       </div>
@@ -438,7 +490,9 @@
       <div class="row">
         <label for="spinDecay">Abklingzeit (s)</label>
         <div class="wrap">
+          <input class="bound-input" type="number" data-target="spinDecay" data-bound="min" />
           <input id="spinDecay" type="range" min="1" max="30" step="1" />
+          <input class="bound-input" type="number" data-target="spinDecay" data-bound="max" />
           <div class="val" id="vSpinDecay"></div>
         </div>
       </div>
@@ -1093,8 +1147,8 @@ function updateRotationUI() {
   spinInertiaBtn.setAttribute('aria-pressed', spinState.inertiaEnabled ? 'true' : 'false');
   spinInertiaBtn.textContent = spinState.inertiaEnabled ? '🪁 Trägheit an' : '🪁 Trägheit aus';
   if (spinDecaySlider) {
+    applySliderValue('spinDecay', spinState.inertiaDuration);
     spinDecaySlider.disabled = !spinState.inertiaEnabled;
-    spinDecaySlider.value = spinState.inertiaDuration;
   }
   if (spinDecayValue) {
     spinDecayValue.textContent = spinState.inertiaDuration.toFixed(0) + ' s';
@@ -1147,7 +1201,22 @@ function setInertiaEnabled(enabled) {
 }
 
 function setInertiaDuration(seconds) {
-  const clamped = Math.max(1, Math.min(30, Math.round(seconds)));
+  let next = Math.round(Number(seconds));
+  if (!Number.isFinite(next)) {
+    next = spinState.inertiaDuration;
+  }
+  let min = 1;
+  let max = 30;
+  const bounds = sliderBoundSettings.spinDecay;
+  if (bounds) {
+    if (Number.isFinite(bounds.min)) {
+      min = bounds.min;
+    }
+    if (Number.isFinite(bounds.max)) {
+      max = bounds.max;
+    }
+  }
+  const clamped = Math.round(clampValue(next, min, max));
   spinState.inertiaDuration = clamped;
   if (spinState.inertiaEnabled && !spinState.isDragging && hasSpinVelocity()) {
     spinState.decayStartSpeed = spinState.velocity.length();
@@ -1267,15 +1336,6 @@ if (spinInertiaBtn) {
     setInertiaEnabled(!spinState.inertiaEnabled);
   });
 }
-if (spinDecaySlider) {
-  spinDecaySlider.addEventListener('input', e => {
-    const next = parseInt(e.target.value, 10);
-    if (!Number.isNaN(next)) {
-      setInertiaDuration(next);
-    }
-  });
-}
-
 function setCategoryPercent(kind, value) {
   const keyMap = { small: 'catSmall', medium: 'catMedium', large: 'catLarge' };
   const key = keyMap[kind];
@@ -1326,13 +1386,13 @@ function setCategoryPercent(kind, value) {
   }
 }
 
-function getSizeRange() {
-  const min = Math.max(0.05, 1 - params.sizeVar * 0.5);
-  const max = 1 + params.sizeVar * 0.5;
+function getSizeRange(sizeVar = params.sizeVar) {
+  const min = Math.max(0.05, 1 - sizeVar * 0.5);
+  const max = 1 + sizeVar * 0.5;
   return { min, max, delta: max - min };
 }
 
-const sliders = {
+const sliderHandlers = {
   pCount:       val => { params.count = parseInt(val, 10); rebuildStars(); },
   pRadius:      val => { params.radius = parseFloat(val); rebuildStars(); },
   pSizeVar:     val => { params.sizeVar = parseFloat(val); rebuildStars(); },
@@ -1352,11 +1412,220 @@ const sliders = {
   pTinyAlpha:   val => { params.tinyAlpha = parseFloat(val); updateTinyMaterial(); },
   pSeedTiny:    val => { params.seedTiny = parseInt(val, 10); rebuildTiny(); },
   pEdgeSoft:    val => { params.edgeSoftness = parseFloat(val); updateStarUniforms(); },
+  spinDecay:    val => { const next = parseFloat(val); if (!Number.isNaN(next)) { setInertiaDuration(next); } },
 };
+
+const sliderValueGetters = {
+  pCount:       () => params.count,
+  pRadius:      () => params.radius,
+  pSizeVar:     () => params.sizeVar,
+  pCluster:     () => params.cluster,
+  pPointAlpha:  () => params.pointAlpha,
+  pHue:         () => params.pointHue,
+  pSeedStars:   () => params.seedStars,
+  pCatSmall:    () => params.catSmall,
+  pCatMedium:   () => params.catMedium,
+  pCatLarge:    () => params.catLarge,
+  pSizeTiny:    () => params.sizeFactorTiny,
+  pSizeSmall:   () => params.sizeFactorSmall,
+  pSizeMedium:  () => params.sizeFactorMedium,
+  pSizeLarge:   () => params.sizeFactorLarge,
+  pTinyCount:   () => params.tinyCount,
+  pConnPercent: () => params.connPercent,
+  pTinyAlpha:   () => params.tinyAlpha,
+  pSeedTiny:    () => params.seedTiny,
+  pEdgeSoft:    () => params.edgeSoftness,
+  spinDecay:    () => spinState.inertiaDuration,
+};
+
+const sliderBoundSettings = {};
+const sliderBoundInputs = {};
+
+function clampValue(value, min, max) {
+  let next = Number(value);
+  if (!Number.isFinite(next)) return next;
+  let minVal = Number.isFinite(min) ? min : Number.NEGATIVE_INFINITY;
+  let maxVal = Number.isFinite(max) ? max : Number.POSITIVE_INFINITY;
+  if (minVal > maxVal) {
+    const tmp = minVal;
+    minVal = maxVal;
+    maxVal = tmp;
+  }
+  if (Number.isFinite(minVal)) {
+    next = Math.max(next, minVal);
+  }
+  if (Number.isFinite(maxVal)) {
+    next = Math.min(next, maxVal);
+  }
+  return next;
+}
+
+function formatDisplayNumber(value, fractionDigits = 2) {
+  if (!Number.isFinite(value)) return '';
+  return Number.isInteger(value) ? String(value) : value.toFixed(fractionDigits);
+}
+
+function syncSliderUI(id) {
+  const slider = $(id);
+  const settings = sliderBoundSettings[id];
+  if (!slider || !settings) return;
+  slider.min = settings.min;
+  slider.max = settings.max;
+  const boundPair = sliderBoundInputs[id];
+  if (boundPair && boundPair.min && document.activeElement !== boundPair.min) {
+    boundPair.min.value = settings.min;
+  }
+  if (boundPair && boundPair.max && document.activeElement !== boundPair.max) {
+    boundPair.max.value = settings.max;
+  }
+}
+
+function handleBoundInputChange(id, kind, inputEl) {
+  const settings = sliderBoundSettings[id];
+  if (!settings) return;
+  let value = parseFloat(inputEl.value);
+  if (!Number.isFinite(value)) {
+    inputEl.value = settings[kind];
+    return;
+  }
+  if (kind === 'min') {
+    settings.min = value;
+    if (value > settings.max) {
+      settings.max = value;
+      const partner = sliderBoundInputs[id] && sliderBoundInputs[id].max;
+      if (partner) {
+        partner.value = settings.max;
+      }
+    }
+  } else {
+    settings.max = value;
+    if (value < settings.min) {
+      settings.min = value;
+      const partner = sliderBoundInputs[id] && sliderBoundInputs[id].min;
+      if (partner) {
+        partner.value = settings.min;
+      }
+    }
+  }
+  inputEl.value = settings[kind];
+  syncSliderUI(id);
+  const getter = sliderValueGetters[id];
+  const handler = sliderHandlers[id];
+  if (getter && handler) {
+    const current = getter();
+    if (Number.isFinite(current)) {
+      const clamped = clampValue(current, settings.min, settings.max);
+      if (clamped !== current) {
+        handler(String(clamped));
+      }
+    }
+  }
+  setSliders();
+}
+
+function registerSliderBounds(id) {
+  const slider = $(id);
+  if (!slider) return;
+  let min = parseFloat(slider.getAttribute('min'));
+  let max = parseFloat(slider.getAttribute('max'));
+  if (!Number.isFinite(min) && Number.isFinite(max)) {
+    min = max < 0 ? max : 0;
+  }
+  if (!Number.isFinite(max) && Number.isFinite(min)) {
+    max = min > 0 ? min : 1;
+  }
+  if (!Number.isFinite(min)) min = 0;
+  if (!Number.isFinite(max)) max = min;
+  if (min > max) {
+    const tmp = min;
+    min = max;
+    max = tmp;
+  }
+  sliderBoundSettings[id] = { min, max };
+  const wrap = slider.closest('.wrap');
+  const labelElement = document.querySelector(`label[for="${id}"]`);
+  let descriptor = '';
+  if (labelElement) {
+    descriptor = labelElement.textContent ? labelElement.textContent.replace(/\s+/g, ' ').trim() : '';
+  } else if (wrap) {
+    const tag = wrap.querySelector('.tag');
+    if (tag && tag.textContent) {
+      descriptor = tag.textContent.replace(/\s+/g, ' ').trim();
+    }
+  }
+  const minLabel = descriptor ? `${descriptor} – Minimum` : 'Minimum';
+  const maxLabel = descriptor ? `${descriptor} – Maximum` : 'Maximum';
+  if (wrap) {
+    const minInput = wrap.querySelector(`input[data-target="${id}"][data-bound="min"]`);
+    const maxInput = wrap.querySelector(`input[data-target="${id}"][data-bound="max"]`);
+    sliderBoundInputs[id] = sliderBoundInputs[id] || {};
+    const step = slider.step && slider.step.length ? slider.step : 'any';
+    if (minInput) {
+      sliderBoundInputs[id].min = minInput;
+      minInput.value = min;
+      minInput.step = step;
+      minInput.inputMode = 'decimal';
+      minInput.setAttribute('aria-label', minLabel);
+      minInput.title = minLabel;
+      minInput.addEventListener('change', event => handleBoundInputChange(id, 'min', event.target));
+    }
+    if (maxInput) {
+      sliderBoundInputs[id].max = maxInput;
+      maxInput.value = max;
+      maxInput.step = step;
+      maxInput.inputMode = 'decimal';
+      maxInput.setAttribute('aria-label', maxLabel);
+      maxInput.title = maxLabel;
+      maxInput.addEventListener('change', event => handleBoundInputChange(id, 'max', event.target));
+    }
+  }
+  syncSliderUI(id);
+}
+
+function initializeSliderBounds() {
+  for (const id in sliderHandlers) {
+    registerSliderBounds(id);
+  }
+}
+
+function applySliderValue(id, value) {
+  const slider = $(id);
+  if (!slider) return value;
+  syncSliderUI(id);
+  const settings = sliderBoundSettings[id];
+  let next = value;
+  if (settings && Number.isFinite(value)) {
+    next = clampValue(value, settings.min, settings.max);
+  }
+  slider.value = next;
+  return next;
+}
+
+function enforceBounds() {
+  let changed = false;
+  for (const id in sliderHandlers) {
+    const settings = sliderBoundSettings[id];
+    const getter = sliderValueGetters[id];
+    const handler = sliderHandlers[id];
+    if (!settings || !getter || !handler) continue;
+    const current = getter();
+    if (!Number.isFinite(current)) continue;
+    const clamped = clampValue(current, settings.min, settings.max);
+    if (clamped !== current) {
+      handler(String(clamped));
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+initializeSliderBounds();
 // assign input event handlers
-for (const id in sliders) {
-  $(id).addEventListener('input', e => {
-    sliders[id](e.target.value);
+for (const id in sliderHandlers) {
+  const element = $(id);
+  if (!element) continue;
+  element.addEventListener('input', e => {
+    sliderHandlers[id](e.target.value);
     setSliders();
   });
 }
@@ -1462,6 +1731,7 @@ $('random').addEventListener('click', () => {
   params.edgeSoftness = Math.random();
   params.blending = (Math.random() < 0.5) ? 'Normal' : 'Additive';
   params.filled = Math.random() < 0.3;
+  enforceBounds();
   updatePointColor();
   rebuildStars();
   setSliders();
@@ -1470,31 +1740,36 @@ $('random').addEventListener('click', () => {
 /* Update slider displays */
 function setSliders() {
   // star params
-  $('pCount').value = params.count; $('vCount').textContent = params.count;
-  $('pRadius').value = params.radius; $('vRadius').textContent = params.radius;
+  const countValue = applySliderValue('pCount', params.count);
+  $('vCount').textContent = formatDisplayNumber(countValue);
+  const radiusValue = applySliderValue('pRadius', params.radius);
+  $('vRadius').textContent = formatDisplayNumber(radiusValue, 2);
   $('pDistribution').value = params.distribution;
-  $('pSizeVar').value = params.sizeVar;
-  const sizeRange = getSizeRange();
+  const sizeVarValue = applySliderValue('pSizeVar', params.sizeVar);
+  const sizeRange = getSizeRange(sizeVarValue);
   $('vSizeVar').textContent = sizeRange.delta.toFixed(2);
-  $('pCluster').value = params.cluster; $('vCluster').textContent = params.cluster.toFixed(2);
-  $('pPointAlpha').value = params.pointAlpha; $('vPointAlpha').textContent = params.pointAlpha.toFixed(2);
-  $('pHue').value = params.pointHue; $('vHue').textContent = Math.round(params.pointHue) + '°';
-  $('pSeedStars').value = params.seedStars; $('vSeedStars').textContent = params.seedStars;
-  $('pCatSmall').value = params.catSmall; $('vCatSmall').textContent = params.catSmall + '%';
-  $('pCatMedium').value = params.catMedium; $('vCatMedium').textContent = params.catMedium + '%';
-  $('pCatLarge').value = params.catLarge; $('vCatLarge').textContent = params.catLarge + '%';
+  $('vCluster').textContent = applySliderValue('pCluster', params.cluster).toFixed(2);
+  $('vPointAlpha').textContent = applySliderValue('pPointAlpha', params.pointAlpha).toFixed(2);
+  const hueValue = applySliderValue('pHue', params.pointHue);
+  $('vHue').textContent = formatDisplayNumber(hueValue, 1) + '°';
+  const seedStarsValue = applySliderValue('pSeedStars', params.seedStars);
+  $('vSeedStars').textContent = formatDisplayNumber(seedStarsValue);
+  $('vCatSmall').textContent = formatDisplayNumber(applySliderValue('pCatSmall', params.catSmall)) + '%';
+  $('vCatMedium').textContent = formatDisplayNumber(applySliderValue('pCatMedium', params.catMedium)) + '%';
+  $('vCatLarge').textContent = formatDisplayNumber(applySliderValue('pCatLarge', params.catLarge)) + '%';
   // size factors
-  $('pSizeTiny').value = params.sizeFactorTiny; $('vSizeTiny').textContent = params.sizeFactorTiny.toFixed(2);
-  $('pSizeSmall').value = params.sizeFactorSmall; $('vSizeSmall').textContent = params.sizeFactorSmall.toFixed(2);
-  $('pSizeMedium').value = params.sizeFactorMedium; $('vSizeMedium').textContent = params.sizeFactorMedium.toFixed(2);
-  $('pSizeLarge').value = params.sizeFactorLarge; $('vSizeLarge').textContent = params.sizeFactorLarge.toFixed(2);
+  $('vSizeTiny').textContent = applySliderValue('pSizeTiny', params.sizeFactorTiny).toFixed(2);
+  $('vSizeSmall').textContent = applySliderValue('pSizeSmall', params.sizeFactorSmall).toFixed(2);
+  $('vSizeMedium').textContent = applySliderValue('pSizeMedium', params.sizeFactorMedium).toFixed(2);
+  $('vSizeLarge').textContent = applySliderValue('pSizeLarge', params.sizeFactorLarge).toFixed(2);
   // tiny / connection
-  $('pTinyCount').value = params.tinyCount; $('vTinyCount').textContent = params.tinyCount;
-  $('pConnPercent').value = params.connPercent; $('vConnPercent').textContent = (params.connPercent * 100).toFixed(0) + '%';
-  $('pTinyAlpha').value = params.tinyAlpha; $('vTinyAlpha').textContent = params.tinyAlpha.toFixed(2);
-  $('pSeedTiny').value = params.seedTiny; $('vSeedTiny').textContent = params.seedTiny;
+  $('vTinyCount').textContent = formatDisplayNumber(applySliderValue('pTinyCount', params.tinyCount));
+  const connPercentValue = applySliderValue('pConnPercent', params.connPercent) * 100;
+  $('vConnPercent').textContent = formatDisplayNumber(connPercentValue, 1) + '%';
+  $('vTinyAlpha').textContent = applySliderValue('pTinyAlpha', params.tinyAlpha).toFixed(2);
+  $('vSeedTiny').textContent = formatDisplayNumber(applySliderValue('pSeedTiny', params.seedTiny));
   // edge & blending
-  $('pEdgeSoft').value = params.edgeSoftness; $('vEdgeSoft').textContent = params.edgeSoftness.toFixed(2);
+  $('vEdgeSoft').textContent = applySliderValue('pEdgeSoft', params.edgeSoftness).toFixed(2);
   $('pBlending').value = params.blending;
   $('pFilled').checked = params.filled;
   updateRotationUI();


### PR DESCRIPTION
## Summary
- add min and max number inputs next to parameter sliders so their ranges can be edited without rebuilding the panel markup
- persist custom slider bounds, clamp parameter updates into the allowed range, and update the randomizer to respect the new limits

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df85f8ca488324ae6a0e05ccf13762