### PR TITLE
Add animated motion controls to starfield

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,6 +437,43 @@
     </button>
     <div class="accordion__panel" id="acc-dynamics-panel" role="region" aria-labelledby="acc-dynamics-trigger">
       <div class="row">
+        <label for="pMotionMode">Bewegungsmodus</label>
+        <select id="pMotionMode">
+          <option value="static">Statisch</option>
+          <option value="sine">Sinuswellen</option>
+          <option value="noise">Noise</option>
+          <option value="orbit">Orbit</option>
+        </select>
+      </div>
+      <div class="row">
+        <label for="pMotionSpeed">Bewegungsgeschwindigkeit</label>
+        <div class="wrap">
+          <input id="pMotionSpeed" type="range" min="0" max="3" step="0.01" />
+          <div class="val" id="vMotionSpeed"></div>
+        </div>
+      </div>
+      <div class="row">
+        <label for="pMotionAmplitude">Amplitude</label>
+        <div class="wrap">
+          <input id="pMotionAmplitude" type="range" min="0" max="40" step="0.1" />
+          <div class="val" id="vMotionAmplitude"></div>
+        </div>
+      </div>
+      <div class="row">
+        <label for="pMotionNoiseStrength">Noise-Intensität</label>
+        <div class="wrap">
+          <input id="pMotionNoiseStrength" type="range" min="0" max="2.5" step="0.01" />
+          <div class="val" id="vMotionNoiseStrength"></div>
+        </div>
+      </div>
+      <div class="row">
+        <label for="pMotionNoiseScale">Noise-Skala</label>
+        <div class="wrap">
+          <input id="pMotionNoiseScale" type="range" min="0.1" max="4" step="0.01" />
+          <div class="val" id="vMotionNoiseScale"></div>
+        </div>
+      </div>
+      <div class="row">
         <label>Rotation</label>
         <div class="wrap">
           <button id="autoSpin" aria-pressed="false">🌀 Auto-Rotation aus</button>
@@ -562,10 +599,23 @@ const params = {
   // Edge & blending
   edgeSoftness: 0.6,
   blending: 'Normal',
-  filled: false
+  filled: false,
+  // Motion
+  motionMode: 'static',
+  motionSpeed: 1.0,
+  motionAmplitude: 8.0,
+  motionNoiseStrength: 1.0,
+  motionNoiseScale: 1.0
 };
 
 const colorState = { point: new THREE.Color() };
+const MOTION_MODES = ['static', 'sine', 'noise', 'orbit'];
+const motionState = { time: 0 };
+
+function getMotionModeIndex() {
+  const idx = MOTION_MODES.indexOf(params.motionMode);
+  return idx >= 0 ? idx : 0;
+}
 
 /* Globals for stars and tiny connections */
 let starPoints, starGeometry, starMaterial;
@@ -602,6 +652,8 @@ function makeStars() {
   params.count = total;
   starGeometry = new THREE.BufferGeometry();
   const positions = new Float32Array(total * 3);
+  const basePositions = new Float32Array(total * 3);
+  const phases = new Float32Array(total);
   const sizes = new Float32Array(total);
   const cats  = new Float32Array(total);
   // thresholds for categories based on counts
@@ -615,6 +667,7 @@ function makeStars() {
   const mediumEnd = minSize + span * mediumThreshold;
   // seeded random for star distribution
   const rand = mulberry32(params.seedStars);
+  const phaseRand = mulberry32((params.seedStars ^ 0x51f32a95) >>> 0);
   const catRand = mulberry32(params.seedStars + 0x9e3779b9);
   const categoryPool = [];
   for (let i = 0; i < smallCount; i++) categoryPool.push(0);
@@ -678,6 +731,7 @@ function makeStars() {
       z = r * Math.cos(phi);
     }
     positions.set([x, y, z], i * 3);
+    basePositions.set([x, y, z], i * 3);
     const cat = categoryPool[i] !== undefined ? categoryPool[i] : 2;
     cats[i] = cat;
     let lower = mediumEnd;
@@ -694,15 +748,20 @@ function makeStars() {
     } else {
       sizes[i] = lower + rand() * (upper - lower);
     }
+    phases[i] = phaseRand();
   }
-  starGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const positionAttr = new THREE.BufferAttribute(positions, 3);
+  const baseAttr = new THREE.BufferAttribute(basePositions, 3);
+  const phaseAttr = new THREE.BufferAttribute(phases, 1);
+  starGeometry.setAttribute('position', positionAttr);
+  starGeometry.setAttribute('aBase', baseAttr);
+  starGeometry.setAttribute('aPhase', phaseAttr);
   starGeometry.setAttribute('aSize', new THREE.BufferAttribute(sizes, 1));
   starGeometry.setAttribute('aCat', new THREE.BufferAttribute(cats, 1));
   starGeometry.computeBoundingSphere();
   if (starGeometry.boundingSphere) {
     const center = starGeometry.boundingSphere.center.clone();
     if (center.lengthSq() > 1e-6) {
-      const positionAttr = starGeometry.getAttribute('position');
       for (let i = 0; i < positionAttr.count; i++) {
         positionAttr.setXYZ(
           i,
@@ -710,8 +769,15 @@ function makeStars() {
           positionAttr.getY(i) - center.y,
           positionAttr.getZ(i) - center.z
         );
+        baseAttr.setXYZ(
+          i,
+          baseAttr.getX(i) - center.x,
+          baseAttr.getY(i) - center.y,
+          baseAttr.getZ(i) - center.z
+        );
       }
       positionAttr.needsUpdate = true;
+      baseAttr.needsUpdate = true;
       starGeometry.boundingSphere.center.set(0, 0, 0);
       controls.target.copy(clusterGroup.position);
     }
@@ -720,13 +786,91 @@ function makeStars() {
   const starVert = `
     attribute float aSize;
     attribute float aCat;
+    attribute vec3 aBase;
+    attribute float aPhase;
     varying float vDepth;
-    // uniforms to scale different point categories
     uniform float uSizeFactorSmall;
     uniform float uSizeFactorMedium;
     uniform float uSizeFactorLarge;
+    uniform float uTime;
+    uniform float uMotionMode;
+    uniform float uMotionSpeed;
+    uniform float uMotionAmplitude;
+    uniform float uNoiseStrength;
+    uniform float uNoiseScale;
+
+    float hash3(vec3 p) {
+      return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453123);
+    }
+
+    float valueNoise(vec3 p) {
+      vec3 i = floor(p);
+      vec3 f = fract(p);
+      float n000 = hash3(i + vec3(0.0, 0.0, 0.0));
+      float n100 = hash3(i + vec3(1.0, 0.0, 0.0));
+      float n010 = hash3(i + vec3(0.0, 1.0, 0.0));
+      float n110 = hash3(i + vec3(1.0, 1.0, 0.0));
+      float n001 = hash3(i + vec3(0.0, 0.0, 1.0));
+      float n101 = hash3(i + vec3(1.0, 0.0, 1.0));
+      float n011 = hash3(i + vec3(0.0, 1.0, 1.0));
+      float n111 = hash3(i + vec3(1.0, 1.0, 1.0));
+      vec3 u = f * f * (3.0 - 2.0 * f);
+      float nx00 = mix(n000, n100, u.x);
+      float nx10 = mix(n010, n110, u.x);
+      float nx01 = mix(n001, n101, u.x);
+      float nx11 = mix(n011, n111, u.x);
+      float nxy0 = mix(nx00, nx10, u.y);
+      float nxy1 = mix(nx01, nx11, u.y);
+      return mix(nxy0, nxy1, u.z);
+    }
+
+    vec3 applyMotion(vec3 base) {
+      float mode = uMotionMode;
+      float time = uTime * uMotionSpeed;
+      if (mode < 0.5) {
+        return base;
+      } else if (mode < 1.5) {
+        float phase = aPhase * 6.2831853;
+        vec3 offset = vec3(
+          sin(time + phase + base.x * 0.015),
+          sin(time * 0.8 + phase * 1.3 + base.y * 0.02),
+          sin(time * 1.2 + phase * 0.7 + base.z * 0.017)
+        );
+        return base + offset * uMotionAmplitude;
+      } else if (mode < 2.5) {
+        float scale = max(0.0001, uNoiseScale);
+        vec3 samplePos = base * (0.01 * scale);
+        float tx = valueNoise(vec3(samplePos.xy, time * 0.35 + aPhase));
+        float ty = valueNoise(vec3(samplePos.yz, time * 0.35 + aPhase * 1.7));
+        float tz = valueNoise(vec3(samplePos.zx, time * 0.35 + aPhase * 2.3));
+        vec3 offset = vec3(tx, ty, tz) * 2.0 - 1.0;
+        offset *= uMotionAmplitude * uNoiseStrength;
+        return base + offset;
+      } else {
+        float phase = aPhase * 6.2831853;
+        float angle = time * 0.6 + phase * 0.25;
+        vec2 xz = base.xz;
+        float radius = length(xz);
+        float radial = max(0.0, radius + sin(time * 0.4 + phase) * uMotionAmplitude * 0.25);
+        float c = cos(angle);
+        float s = sin(angle);
+        vec2 rotated = vec2(
+          xz.x * c - xz.y * s,
+          xz.x * s + xz.y * c
+        );
+        if (radial > 1e-4 && length(rotated) > 1e-5) {
+          rotated = normalize(rotated) * radial;
+        } else {
+          rotated = vec2(radial * cos(angle), radial * sin(angle));
+        }
+        float yOffset = sin(time * 0.5 + phase * 0.5) * uMotionAmplitude * 0.3;
+        return vec3(rotated.x, base.y + yOffset, rotated.y);
+      }
+    }
+
     void main() {
-      vec4 mv = modelViewMatrix * vec4(position, 1.0);
+      vec3 animated = applyMotion(aBase);
+      vec4 mv = modelViewMatrix * vec4(animated, 1.0);
       vDepth = -mv.z;
       float factor;
       if (aCat < 0.5) {
@@ -770,6 +914,12 @@ function makeStars() {
       uSizeFactorSmall: { value: params.sizeFactorSmall },
       uSizeFactorMedium: { value: params.sizeFactorMedium },
       uSizeFactorLarge: { value: params.sizeFactorLarge },
+      uTime: { value: motionState.time },
+      uMotionMode: { value: getMotionModeIndex() },
+      uMotionSpeed: { value: params.motionSpeed },
+      uMotionAmplitude: { value: params.motionAmplitude },
+      uNoiseStrength: { value: params.motionNoiseStrength },
+      uNoiseScale: { value: params.motionNoiseScale },
       uColor: { value: colorState.point.clone() }
     }
   });
@@ -789,11 +939,14 @@ function makeTiny() {
   const nTiny = Math.round(params.tinyCount * params.connPercent);
   tinyGeometry = new THREE.BufferGeometry();
   const positions = new Float32Array(Math.max(0, nTiny * 3));
+  const basePositions = new Float32Array(Math.max(0, nTiny * 3));
+  const phases = new Float32Array(Math.max(0, nTiny));
   // Access star positions for connections
-  const starPos = starGeometry.getAttribute('position');
+  const starPos = (starGeometry && starGeometry.getAttribute) ? starGeometry.getAttribute('position') : null;
   const nStars = starPos ? starPos.count : 0;
   if (starPos && nStars > 0) {
     const rand = mulberry32(params.seedTiny);
+    const phaseRand = mulberry32((params.seedTiny ^ 0x9e3779b9) >>> 0);
     for (let i = 0; i < nTiny; i++) {
       // pick two random stars
       const idxA = Math.floor(rand() * nStars);
@@ -806,14 +959,97 @@ function makeTiny() {
       const y = ay + (by - ay) * t;
       const z = az + (bz - az) * t;
       positions.set([x, y, z], i * 3);
+      basePositions.set([x, y, z], i * 3);
+      phases[i] = phaseRand();
     }
   }
   tinyGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  tinyGeometry.setAttribute('aBase', new THREE.BufferAttribute(basePositions, 3));
+  tinyGeometry.setAttribute('aPhase', new THREE.BufferAttribute(phases, 1));
   const tinyVert = `
+    attribute vec3 aBase;
+    attribute float aPhase;
     uniform float uSize;
+    uniform float uTime;
+    uniform float uMotionMode;
+    uniform float uMotionSpeed;
+    uniform float uMotionAmplitude;
+    uniform float uNoiseStrength;
+    uniform float uNoiseScale;
     varying float vDepth;
+
+    float hash3(vec3 p) {
+      return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453123);
+    }
+
+    float valueNoise(vec3 p) {
+      vec3 i = floor(p);
+      vec3 f = fract(p);
+      float n000 = hash3(i + vec3(0.0, 0.0, 0.0));
+      float n100 = hash3(i + vec3(1.0, 0.0, 0.0));
+      float n010 = hash3(i + vec3(0.0, 1.0, 0.0));
+      float n110 = hash3(i + vec3(1.0, 1.0, 0.0));
+      float n001 = hash3(i + vec3(0.0, 0.0, 1.0));
+      float n101 = hash3(i + vec3(1.0, 0.0, 1.0));
+      float n011 = hash3(i + vec3(0.0, 1.0, 1.0));
+      float n111 = hash3(i + vec3(1.0, 1.0, 1.0));
+      vec3 u = f * f * (3.0 - 2.0 * f);
+      float nx00 = mix(n000, n100, u.x);
+      float nx10 = mix(n010, n110, u.x);
+      float nx01 = mix(n001, n101, u.x);
+      float nx11 = mix(n011, n111, u.x);
+      float nxy0 = mix(nx00, nx10, u.y);
+      float nxy1 = mix(nx01, nx11, u.y);
+      return mix(nxy0, nxy1, u.z);
+    }
+
+    vec3 applyMotion(vec3 base) {
+      float mode = uMotionMode;
+      float time = uTime * uMotionSpeed;
+      if (mode < 0.5) {
+        return base;
+      } else if (mode < 1.5) {
+        float phase = aPhase * 6.2831853;
+        vec3 offset = vec3(
+          sin(time + phase + base.x * 0.015),
+          sin(time * 0.8 + phase * 1.3 + base.y * 0.02),
+          sin(time * 1.2 + phase * 0.7 + base.z * 0.017)
+        );
+        return base + offset * uMotionAmplitude;
+      } else if (mode < 2.5) {
+        float scale = max(0.0001, uNoiseScale);
+        vec3 samplePos = base * (0.01 * scale);
+        float tx = valueNoise(vec3(samplePos.xy, time * 0.35 + aPhase));
+        float ty = valueNoise(vec3(samplePos.yz, time * 0.35 + aPhase * 1.7));
+        float tz = valueNoise(vec3(samplePos.zx, time * 0.35 + aPhase * 2.3));
+        vec3 offset = vec3(tx, ty, tz) * 2.0 - 1.0;
+        offset *= uMotionAmplitude * uNoiseStrength;
+        return base + offset;
+      } else {
+        float phase = aPhase * 6.2831853;
+        float angle = time * 0.6 + phase * 0.25;
+        vec2 xz = base.xz;
+        float radius = length(xz);
+        float radial = max(0.0, radius + sin(time * 0.4 + phase) * uMotionAmplitude * 0.25);
+        float c = cos(angle);
+        float s = sin(angle);
+        vec2 rotated = vec2(
+          xz.x * c - xz.y * s,
+          xz.x * s + xz.y * c
+        );
+        if (radial > 1e-4 && length(rotated) > 1e-5) {
+          rotated = normalize(rotated) * radial;
+        } else {
+          rotated = vec2(radial * cos(angle), radial * sin(angle));
+        }
+        float yOffset = sin(time * 0.5 + phase * 0.5) * uMotionAmplitude * 0.3;
+        return vec3(rotated.x, base.y + yOffset, rotated.y);
+      }
+    }
+
     void main() {
-      vec4 mv = modelViewMatrix * vec4(position, 1.0);
+      vec3 animated = applyMotion(aBase);
+      vec4 mv = modelViewMatrix * vec4(animated, 1.0);
       vDepth = -mv.z;
       float px = max(1.0, uSize * 6.0);
       gl_PointSize = px * (300.0 / max(1.0, vDepth));
@@ -841,6 +1077,12 @@ function makeTiny() {
     uniforms: {
       uAlpha: { value: params.tinyAlpha },
       uSize: { value: params.sizeFactorTiny },
+      uTime: { value: motionState.time },
+      uMotionMode: { value: getMotionModeIndex() },
+      uMotionSpeed: { value: params.motionSpeed },
+      uMotionAmplitude: { value: params.motionAmplitude },
+      uNoiseStrength: { value: params.motionNoiseStrength },
+      uNoiseScale: { value: params.motionNoiseScale },
       uColor: { value: colorState.point.clone() }
     }
   });
@@ -857,6 +1099,24 @@ function updateStarUniforms() {
   starMaterial.uniforms.uSizeFactorSmall.value = params.sizeFactorSmall;
   starMaterial.uniforms.uSizeFactorMedium.value = params.sizeFactorMedium;
   starMaterial.uniforms.uSizeFactorLarge.value = params.sizeFactorLarge;
+  if (starMaterial.uniforms.uTime) {
+    starMaterial.uniforms.uTime.value = motionState.time;
+  }
+  if (starMaterial.uniforms.uMotionMode) {
+    starMaterial.uniforms.uMotionMode.value = getMotionModeIndex();
+  }
+  if (starMaterial.uniforms.uMotionSpeed) {
+    starMaterial.uniforms.uMotionSpeed.value = params.motionSpeed;
+  }
+  if (starMaterial.uniforms.uMotionAmplitude) {
+    starMaterial.uniforms.uMotionAmplitude.value = params.motionAmplitude;
+  }
+  if (starMaterial.uniforms.uNoiseStrength) {
+    starMaterial.uniforms.uNoiseStrength.value = params.motionNoiseStrength;
+  }
+  if (starMaterial.uniforms.uNoiseScale) {
+    starMaterial.uniforms.uNoiseScale.value = params.motionNoiseScale;
+  }
   if (starMaterial.uniforms.uColor) {
     starMaterial.uniforms.uColor.value.copy(colorState.point);
   }
@@ -868,6 +1128,24 @@ function updateTinyMaterial() {
   if (!tinyMaterial) return;
   tinyMaterial.uniforms.uAlpha.value = params.tinyAlpha;
   tinyMaterial.uniforms.uSize.value = params.sizeFactorTiny;
+  if (tinyMaterial.uniforms.uTime) {
+    tinyMaterial.uniforms.uTime.value = motionState.time;
+  }
+  if (tinyMaterial.uniforms.uMotionMode) {
+    tinyMaterial.uniforms.uMotionMode.value = getMotionModeIndex();
+  }
+  if (tinyMaterial.uniforms.uMotionSpeed) {
+    tinyMaterial.uniforms.uMotionSpeed.value = params.motionSpeed;
+  }
+  if (tinyMaterial.uniforms.uMotionAmplitude) {
+    tinyMaterial.uniforms.uMotionAmplitude.value = params.motionAmplitude;
+  }
+  if (tinyMaterial.uniforms.uNoiseStrength) {
+    tinyMaterial.uniforms.uNoiseStrength.value = params.motionNoiseStrength;
+  }
+  if (tinyMaterial.uniforms.uNoiseScale) {
+    tinyMaterial.uniforms.uNoiseScale.value = params.motionNoiseScale;
+  }
   if (tinyMaterial.uniforms.uColor) {
     tinyMaterial.uniforms.uColor.value.copy(colorState.point);
   }
@@ -1491,6 +1769,38 @@ const sliders = {
   pTinyAlpha:   val => { params.tinyAlpha = parseFloat(val); updateTinyMaterial(); },
   pSeedTiny:    val => { params.seedTiny = parseInt(val, 10); rebuildTiny(); },
   pEdgeSoft:    val => { params.edgeSoftness = parseFloat(val); updateStarUniforms(); },
+  pMotionSpeed: val => {
+    const next = parseFloat(val);
+    if (!Number.isNaN(next)) {
+      params.motionSpeed = next;
+      updateStarUniforms();
+      updateTinyMaterial();
+    }
+  },
+  pMotionAmplitude: val => {
+    const next = parseFloat(val);
+    if (!Number.isNaN(next)) {
+      params.motionAmplitude = next;
+      updateStarUniforms();
+      updateTinyMaterial();
+    }
+  },
+  pMotionNoiseStrength: val => {
+    const next = parseFloat(val);
+    if (!Number.isNaN(next)) {
+      params.motionNoiseStrength = next;
+      updateStarUniforms();
+      updateTinyMaterial();
+    }
+  },
+  pMotionNoiseScale: val => {
+    const next = parseFloat(val);
+    if (!Number.isNaN(next)) {
+      params.motionNoiseScale = next;
+      updateStarUniforms();
+      updateTinyMaterial();
+    }
+  },
 };
 // assign input event handlers
 for (const id in sliders) {
@@ -1508,6 +1818,12 @@ $('pBlending').addEventListener('change', e => {
 $('pDistribution').addEventListener('change', e => {
   params.distribution = e.target.value;
   rebuildStars();
+  setSliders();
+});
+$('pMotionMode').addEventListener('change', e => {
+  params.motionMode = e.target.value;
+  updateStarUniforms();
+  updateTinyMaterial();
   setSliders();
 });
 // Filled checkbox
@@ -1615,6 +1931,12 @@ $('random').addEventListener('click', () => {
   params.edgeSoftness = Math.random();
   params.blending = (Math.random() < 0.5) ? 'Normal' : 'Additive';
   params.filled = Math.random() < 0.3;
+  const motionModes = MOTION_MODES;
+  params.motionMode = motionModes[Math.floor(Math.random() * motionModes.length)];
+  params.motionSpeed = Math.random() * 2.5;
+  params.motionAmplitude = Math.random() * 30;
+  params.motionNoiseStrength = Math.random() * 2.0;
+  params.motionNoiseScale = 0.1 + Math.random() * 3.5;
   updatePointColor();
   rebuildStars();
   setSliders();
@@ -1651,6 +1973,12 @@ function setSliders() {
   $('pConnPercent').value = params.connPercent; $('vConnPercent').textContent = (params.connPercent * 100).toFixed(0) + '%';
   $('pTinyAlpha').value = params.tinyAlpha; $('vTinyAlpha').textContent = params.tinyAlpha.toFixed(2);
   $('pSeedTiny').value = params.seedTiny; $('vSeedTiny').textContent = params.seedTiny;
+  // motion
+  $('pMotionMode').value = params.motionMode;
+  $('pMotionSpeed').value = params.motionSpeed; $('vMotionSpeed').textContent = params.motionSpeed.toFixed(2) + '×';
+  $('pMotionAmplitude').value = params.motionAmplitude; $('vMotionAmplitude').textContent = params.motionAmplitude.toFixed(1);
+  $('pMotionNoiseStrength').value = params.motionNoiseStrength; $('vMotionNoiseStrength').textContent = params.motionNoiseStrength.toFixed(2);
+  $('pMotionNoiseScale').value = params.motionNoiseScale; $('vMotionNoiseScale').textContent = params.motionNoiseScale.toFixed(2);
   // edge & blending
   $('pEdgeSoft').value = params.edgeSoftness; $('vEdgeSoft').textContent = params.edgeSoftness.toFixed(2);
   $('pBlending').value = params.blending;
@@ -1686,6 +2014,17 @@ function animate(now) {
   const current = (typeof now === 'number') ? now : performance.now();
   const delta = Math.min(Math.max((current - lastFrameTime) / 1000, 0), 0.25);
   lastFrameTime = current;
+
+  motionState.time += delta;
+  if (motionState.time > 1e6) {
+    motionState.time = 0;
+  }
+  if (starMaterial && starMaterial.uniforms && starMaterial.uniforms.uTime) {
+    starMaterial.uniforms.uTime.value = motionState.time;
+  }
+  if (tinyMaterial && tinyMaterial.uniforms && tinyMaterial.uniforms.uTime) {
+    tinyMaterial.uniforms.uTime.value = motionState.time;
+  }
 
   if (spinState.autoEnabled && !spinState.isDragging) {
     updateVelocityFromComponents();


### PR DESCRIPTION
## Summary
- add motion mode selection and sliders for speed, amplitude, and noise parameters in the dynamics panel
- store base positions and per-point phases to animate stars via shader-driven sine, noise, and orbit modes
- keep tiny connection points in sync and advance motion time uniforms inside the animation loop

## Testing
- not run (manual testing required)


------
https://chatgpt.com/codex/tasks/task_e_68df8a70e1b08324a08a0263c18efe0e