### PR TITLE
fix: guard tiny connectors when no star positions

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,12 +787,17 @@ function makeTiny() {
   }
   // Determine number of tiny points based on connPercent
   const nTiny = Math.round(params.tinyCount * params.connPercent);
-  tinyGeometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(Math.max(0, nTiny * 3));
   // Access star positions for connections
   const starPos = starGeometry.getAttribute('position');
   const nStars = starPos ? starPos.count : 0;
-  if (starPos && nStars > 0) {
+  if (!starPos || nStars === 0) {
+    tinyPoints = undefined;
+    return;
+  }
+
+  tinyGeometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(Math.max(0, nTiny * 3));
+  if (nTiny > 0 && nStars > 0) {
     const rand = mulberry32(params.seedTiny);
     for (let i = 0; i < nTiny; i++) {
       // pick two random stars


### PR DESCRIPTION
## Summary
- stop rebuilding tiny connector points when star positions are unavailable or empty
- only populate connector positions when both star and tiny point counts are positive to avoid NaN values

## Testing
- playwright smoke test reducing all point categories to zero and confirming no NaN connectors

------
https://chatgpt.com/codex/tasks/task_e_68df8bbf2a3c832495b56d5d07472b97