### PR TITLE
docs: clarify ssh fallback instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,16 @@
        chmod 600 ~/.ssh/config
        ```
 
-     - Setze Remote auf SSH:
-       ```bash
-       git remote set-url origin git@github.com:cognifex/OrderlyChaos.git
-       ```
+    - Setze Remote auf SSH **nur, wenn explizit HTTPS-Probleme bestehen und der Wechsel gewünscht ist** (ansonsten diesen Schritt überspringen). Überspringe diesen Schritt ebenfalls, wenn `$GIT_REMOTE_URL` bereits gesetzt wurde oder wenn du auf einem Fork arbeitest.
+      ```bash
+      # Nur ausführen, wenn origin wirklich auf SSH umgestellt werden soll
+      git remote set-url origin git@github.com:cognifex/OrderlyChaos.git
+      ```
+
+      > ℹ️ Alternativ kannst du einen separaten Remote hinzufügen, z. B. `ssh-origin`, um den bestehenden `origin` nicht zu überschreiben:
+      > ```bash
+      > git remote add ssh-origin git@github.com:cognifex/OrderlyChaos.git
+      > ```
 
   6. **Verbindung testen:**
   ```bash


### PR DESCRIPTION
## Summary
- clarify that switching the origin remote to SSH is optional and should only happen on explicit request
- note that the SSH remote change is skipped when $GIT_REMOTE_URL is provided or when working on a fork
- mention adding a separate ssh-origin remote as an alternative to replacing origin

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df9d33fb3883248bd369651fb589a5