### PR TITLE
Add remote bootstrap helper for conflict remediation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,10 @@
      fi
      ```
 
-     - Wenn keine URL gesetzt ist, bitte `GIT_REMOTE_URL` (z. B. `https://github.com/<owner>/<repo>.git`) bereitstellen.
+     - Wenn keine URL gesetzt ist, bitte `GIT_REMOTE_URL` (z. B. `https://github.com/<owner>/<repo>.git`) bereitstellen.
 
   3. **GitHub CLI installieren (falls nicht vorhanden):**
-     - Prüfe zuerst, ob bereits eine ausführbare Datei vorhanden ist (z. B. `/usr/local/bin/gh` oder in `/opt/gh/bin`). Falls ja, ergänze den Pfad:
+     - Prüfe zuerst, ob bereits eine ausführbare Datei vorhanden ist (z. B. `/usr/local/bin/gh` oder in `/opt/gh/bin`). Falls ja, ergänze den Pfad:
        ```bash
        if ! command -v gh &> /dev/null && [ -x "/opt/gh/bin/gh" ]; then
          export PATH="/opt/gh/bin:$PATH"
@@ -58,7 +58,7 @@
        echo "     git remote set-url origin https://github.com/<owner>/<repo>.git"
        echo "     git config user.name \"${GIT_USER_NAME:-Your Name}\""
        echo "     git config user.email \"${GIT_USER_EMAIL:-you@example.com}\""
-       echo "     GH_TOKEN/GITHUB_TOKEN beim Push als Passwort nutzen (z. B. git push https://x-access-token:${GH_TOKEN:-<PAT>}@github.com/<owner>/<repo>.git work)."
+       echo "     GH_TOKEN/GITHUB_TOKEN beim Push als Passwort nutzen (z. B. git push https://x-access-token:${GH_TOKEN:-<PAT>}@github.com/<owner>/<repo>.git work)."
        echo "   Alternativ: Personal Access Token manuell eingeben, wenn Git nach Credentials fragt."
      fi
      ```
@@ -115,50 +115,44 @@
   else
     ssh -T git@github.com || true
   fi
-Push-Befehl:
+  ```
 
-bash
-Code kopieren
-git push -u origin work
-Workflow-Erinnerungen
-Arbeite ausschließlich auf dem Branch work. Falls er noch nicht existiert, von main aus erstellen.
+  7. **Push-Befehl:**
+  ```bash
+  git push -u origin work
+  ```
 
-Vor jeder Änderung synchronisieren:
+## Workflow-Erinnerungen
 
-bash
-Code kopieren
-git fetch origin
-git pull --ff-only origin work || git pull --rebase origin work
-Nach Änderungen immer git add -A und konventionelle Commits nutzen (z. B. feat:, fix:, Doku mit [skip ci]).
+- Arbeite ausschließlich auf dem Branch `work`. Falls er noch nicht existiert, von `main` aus erstellen.
+- Vor jeder Änderung synchronisieren:
+  ```bash
+  git fetch origin
+  git pull --ff-only origin work || git pull --rebase origin work
+  ```
+- Nach Änderungen immer `git add -A` und konventionelle Commits nutzen (z. B. `feat:`, `fix:`, Doku mit `[skip ci]`).
+- Direkt nach jedem Commit pushen. Erster Push: `git push -u origin work`, danach `git push`.
 
-Direkt nach jedem Commit pushen. Erster Push: git push -u origin work, danach git push.
+### Merge-Konflikte in bestehenden Pull-Requests beheben
 
-Merge-Konflikte in bestehenden Pull-Requests beheben
-Hole den aktuellen Stand von main und dem betroffenen PR-Branch:
+- Hole den aktuellen Stand von `main` und dem betroffenen PR-Branch:
+  ```bash
+  git fetch origin
+  git switch <feature-branch>
+  git pull --rebase origin main
+  ```
+- Löse Konflikte lokal und committe die Auflösung.
+- Synchronisiere anschließend den Branch (z. B. `git push --force-with-lease origin <feature-branch>`), damit der PR aktualisiert wird.
+- Falls der PR einem Fork gehört, wähle den passenden Remote (z. B. `git remote add upstream …`) und ziehe die Änderungen entsprechend.
 
-bash
-Code kopieren
-git fetch origin
-git switch <feature-branch>
-git pull --rebase origin main
-Löse Konflikte lokal und committe die Auflösung.
+## Qualitätssicherung
 
-Synchronisiere anschließend den Branch (z. B. git push --force-with-lease origin <feature-branch>), damit der PR aktualisiert wird.
+- Respektiere vorhandene Lockfiles und nutze die passenden Install-Befehle (`pnpm i --frozen-lockfile`, `npm ci`, `yarn install --frozen-lockfile`, `pip install -r requirements.txt`, …).
+- Führe bei Codeänderungen die relevanten Linter und Tests aus. Wenn nur Dokumentation angepasst wird, darf mit `[skip ci]` committet werden.
+- Keine Secrets in Dateien oder Logs ablegen; stattdessen Umgebungsvariablen verwenden.
 
-Falls der PR einem Fork gehört, wähle den passenden Remote (z. B. git remote add upstream …) und ziehe die Änderungen entsprechend.
+## Transparenz & Kommunikation
 
-Qualitätssicherung
-Respektiere vorhandene Lockfiles und nutze die passenden Install-Befehle (pnpm i --frozen-lockfile, npm ci, yarn install --frozen-lockfile, pip install -r requirements.txt, …).
-
-Führe bei Codeänderungen die relevanten Linter und Tests aus. Wenn nur Dokumentation angepasst wird, darf mit [skip ci] committet werden.
-
-Keine Secrets in Dateien oder Logs ablegen; stattdessen Umgebungsvariablen verwenden.
-
-Transparenz & Kommunikation
-Größere Änderungen vorher kurz planen (Scope, Deliverables, Tests, Annahmen).
-
-Nach dem Push Commit-SHA und Link bereitstellen.
-
-Blockaden früh melden und mögliche Lösungen skizzieren.
-
-Code kopieren
+- Größere Änderungen vorher kurz planen (Scope, Deliverables, Tests, Annahmen).
+- Nach dem Push Commit-SHA und Link bereitstellen.
+- Blockaden früh melden und mögliche Lösungen skizzieren.

--- a/docs/git-remote-url-troubleshooting.md
+++ b/docs/git-remote-url-troubleshooting.md
@@ -1,0 +1,45 @@
+# Git Remote URL Troubleshooting
+
+Viele der älteren Automationsskripte und Dokumente beziehen sich auf eine Umgebungsvariable namens `GitRemoteURL`, während neuere
+Playbooks `GIT_REMOTE_URL` (mit Unterstrichen) verwenden. Wenn weder die eine noch die andere Variante gesetzt ist, schlagen Skripte
+wie das Rebase-Playbook mit der Meldung `GitRemoteURL not set` fehl.
+
+## Vorgehen
+
+1. **Vorhandene Variablen prüfen**
+   ```bash
+   echo "GIT_REMOTE_URL=${GIT_REMOTE_URL:-<leer>}"
+   echo "GitRemoteURL=${GitRemoteURL:-<leer>}"
+   ```
+   - Ist nur die CamelCase-Variante gefüllt, kann sie temporär gespiegelt werden:
+     ```bash
+     export GIT_REMOTE_URL="$GitRemoteURL"
+     ```
+
+2. **Skript zur Remote-Konfiguration nutzen**
+   ```bash
+   GIT_REMOTE_URL="https://github.com/<owner>/<repo>.git" ./scripts/bootstrap-remote.sh
+   ```
+   - Das Skript akzeptiert automatisch auch `GitRemoteURL` oder `GITREMOTEURL`, falls `GIT_REMOTE_URL` leer ist.
+   - Mit `--skip-fetch` lässt sich ein sofortiger `git fetch` unterdrücken (z. B. in Offline-Snapshots).
+
+3. **GitHub Actions / CI**
+   ```yaml
+   env:
+     GIT_REMOTE_URL: ${{ secrets.GIT_REMOTE_URL }}
+   ```
+   - Falls das Secret anders heißt (`GitRemoteURL`), kann es ebenfalls gemappt werden:
+     ```yaml
+     env:
+       GIT_REMOTE_URL: ${{ secrets.GitRemoteURL }}
+     ```
+
+4. **Fehler weiterhin vorhanden?**
+   - Prüfe, ob `scripts/bootstrap-remote.sh` aus dem Repository verfügbar ist (mindestens Commit `ce4b9ea`).
+   - Falls das Skript in einer anderen Umgebung läuft, eventuell `git remote set-url origin ...` manuell ausführen.
+   - Notiere den Befehl und die Shell-Ausgabe im Projekt-Log, damit nachvollzogen werden kann, wann der Remote gesetzt wurde.
+
+## Hintergrund
+
+Der neue Workflow vereinheitlicht alle Dokumente auf `GIT_REMOTE_URL`, die CamelCase-Schreibweise bleibt als Fallback erhalten. So
+können vorhandene Secrets/Variablen weitergenutzt werden, ohne dass mehrere Systeme parallel angepasst werden müssen.

--- a/docs/pr-conflict-plan-2025-10-03.md
+++ b/docs/pr-conflict-plan-2025-10-03.md
@@ -24,6 +24,8 @@
 
 ## Detaillierter Aufgabenplan
 1. **Baseline vorbereiten**
+   - Remote-Verbindung per Skript herstellen: `GIT_REMOTE_URL=<https-url> ./scripts/bootstrap-remote.sh`
+     - Alternativ akzeptiert das Skript auch `GitRemoteURL` (CamelCase) aus älteren Setups.
    - `git fetch origin` (sobald Remote-Zugriff verfügbar) und lokale Aktualisierung von `main` (`git pull --ff-only origin main`).
    - Für jede Branch-Serie einen Arbeitsbranch `work/pr-<nr>-rebase` anlegen, um Zwischenschritte getrennt zu halten.
    - Smoke-Test-Szenario definieren: Laden der Demo-Seite, Interaktion mit Panel, Konsole auf Fehler prüfen.

--- a/scripts/bootstrap-remote.sh
+++ b/scripts/bootstrap-remote.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we are inside the git repository root.
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$repo_root" ]]; then
+  echo "[error] Not inside a git repository." >&2
+  exit 1
+fi
+cd "$repo_root"
+
+# Accept multiple environment variable spellings for compatibility.
+remote_url="${GIT_REMOTE_URL:-}"
+if [[ -z "$remote_url" ]]; then
+  remote_url="${GitRemoteURL:-}"
+fi
+if [[ -z "$remote_url" ]]; then
+  remote_url="${GITREMOTEURL:-}"
+fi
+
+if [[ -z "$remote_url" ]]; then
+  cat >&2 <<'MSG'
+[error] No remote URL provided.
+Set one of the following environment variables before running this script:
+  * GIT_REMOTE_URL
+  * GitRemoteURL
+  * GITREMOTEURL
+Example (Linux/macOS):
+  export GIT_REMOTE_URL="https://github.com/<owner>/<repo>.git"
+For GitHub Actions, expose the secret explicitly:
+  env:
+    GIT_REMOTE_URL: ${{ secrets.GIT_REMOTE_URL }}
+MSG
+  exit 1
+fi
+
+current_url=$(git remote get-url origin 2>/dev/null || true)
+if [[ -n "$current_url" ]]; then
+  if [[ "$current_url" == "$remote_url" ]]; then
+    action="kept"
+  else
+    git remote set-url origin "$remote_url"
+    action="updated"
+  fi
+else
+  git remote add origin "$remote_url"
+  action="added"
+fi
+
+echo "[info] origin remote ${action} -> $remote_url"
+
+if [[ "${1:-}" != "--skip-fetch" ]]; then
+  git fetch origin --prune
+fi


### PR DESCRIPTION
## Summary
- add a reusable bootstrap script that configures the `origin` remote using either `GIT_REMOTE_URL` or legacy `GitRemoteURL` variables
- document the new helper in the conflict remediation playbook and explain the variable mapping
- add a troubleshooting guide that walks through resolving the `GitRemoteURL not set` error

## Testing
- `GIT_REMOTE_URL="https://github.com/cognifex/OrderlyChaos.git" scripts/bootstrap-remote.sh --skip-fetch`
- `GitRemoteURL="https://example.com/foo.git" scripts/bootstrap-remote.sh --skip-fetch`
- `scripts/bootstrap-remote.sh --skip-fetch`
- `GIT_REMOTE_URL="https://github.com/cognifex/OrderlyChaos.git" scripts/bootstrap-remote.sh`


------
https://chatgpt.com/codex/tasks/task_e_68dfb72417148324afb07c7e671d2946