### PR TITLE
fix: restore rendering after audio modifier refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1126,6 +1126,7 @@ function updateAudioReactive(delta) {
   const targetScale = Math.min(2.2, 1 + audioState.metrics.energy * 0.45 + audioState.metrics.wave * 0.35 + audioState.metrics.bass * 0.25);
   const targetHue = audioState.metrics.treble * 90;
   const targetAlpha = Math.min(0.5, audioState.metrics.energy * 0.35 + audioState.metrics.wave * 0.2);
+  const modifiers = audioState.modifiers || {};
 
   audioState.visual.motion = damp(audioState.visual.motion, modifiers.motion ? targetMotion : AUDIO_VISUAL_BASE.motion, 6, delta);
   audioState.visual.size = damp(audioState.visual.size, modifiers.size ? targetSize : AUDIO_VISUAL_BASE.size, 7, delta);


### PR DESCRIPTION
## Summary
- prevent the audio reactive update loop from accessing an undefined `modifiers` reference so rendering can resume

## Testing
- manual smoke test in browser (Playwright) to ensure scene renders without runtime errors

------
https://chatgpt.com/codex/tasks/task_e_68dfe0c5834483248b1c2151414d796c