### PR TITLE
feat: bind audio controls to visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,6 +801,105 @@ const audioUI = {
 
 const audioBandVector = new THREE.Vector3();
 
+function applyAudioVisualState(modifiers = audioState.modifiers || {}) {
+  const sizeBoost = modifiers.size ? audioState.visual.size : AUDIO_VISUAL_BASE.size;
+  const hueOffset = modifiers.hue ? audioState.visual.hue : AUDIO_VISUAL_BASE.hue;
+  const saturationBoost = modifiers.saturation ? audioState.metrics.treble * 0.18 : 0;
+  const brightnessBoost = modifiers.brightness ? audioState.metrics.energy * 0.25 : 0;
+  const hue = (params.pointHue + hueOffset) % 360;
+  const saturation = Math.min(1, params.pointSaturation + saturationBoost);
+  const brightness = Math.min(1.1, params.pointValue + brightnessBoost);
+  const reactiveColor = hsv2rgb(hue, saturation, brightness);
+  audioState.color.copy(reactiveColor);
+
+  const targetScale = modifiers.scale ? audioState.visual.scale : AUDIO_VISUAL_BASE.scale;
+  const sphereScale = Math.max(0.35, Math.min(2.2, targetScale));
+  if (Number.isFinite(sphereScale)) {
+    if (Math.abs(clusterGroup.scale.x - sphereScale) > 1e-4 ||
+        Math.abs(clusterGroup.scale.y - sphereScale) > 1e-4 ||
+        Math.abs(clusterGroup.scale.z - sphereScale) > 1e-4) {
+      clusterGroup.scale.setScalar(sphereScale);
+    }
+  }
+
+  audioBandVector.set(audioState.metrics.bass, audioState.metrics.mid, audioState.metrics.treble);
+
+  if (starMaterial && starMaterial.uniforms) {
+    if (starMaterial.uniforms.uAudioBands && starMaterial.uniforms.uAudioBands.value) {
+      starMaterial.uniforms.uAudioBands.value.copy(audioBandVector);
+    }
+    if (starMaterial.uniforms.uAudioEnergy) {
+      starMaterial.uniforms.uAudioEnergy.value = audioState.metrics.energy;
+    }
+    if (starMaterial.uniforms.uAudioWave) {
+      starMaterial.uniforms.uAudioWave.value = audioState.metrics.wave;
+    }
+    if (starMaterial.uniforms.uSizeFactorSmall) {
+      starMaterial.uniforms.uSizeFactorSmall.value = params.sizeFactorSmall * sizeBoost;
+    }
+    if (starMaterial.uniforms.uSizeFactorMedium) {
+      starMaterial.uniforms.uSizeFactorMedium.value = params.sizeFactorMedium * sizeBoost;
+    }
+    if (starMaterial.uniforms.uSizeFactorLarge) {
+      starMaterial.uniforms.uSizeFactorLarge.value = params.sizeFactorLarge * sizeBoost;
+    }
+    if (starMaterial.uniforms.uAlpha) {
+      const baseAlpha = params.pointAlpha;
+      const alphaBoost = modifiers.alpha ? audioState.visual.alpha : AUDIO_VISUAL_BASE.alpha;
+      const boostedAlpha = Math.max(0.05, Math.min(1, baseAlpha + alphaBoost));
+      starMaterial.uniforms.uAlpha.value = boostedAlpha;
+    }
+    if (starMaterial.uniforms.uColor) {
+      starMaterial.uniforms.uColor.value.copy(audioState.color);
+    }
+  }
+
+  if (tinyMaterial && tinyMaterial.uniforms) {
+    if (tinyMaterial.uniforms.uAudioBands && tinyMaterial.uniforms.uAudioBands.value) {
+      tinyMaterial.uniforms.uAudioBands.value.copy(audioBandVector);
+    }
+    if (tinyMaterial.uniforms.uAudioEnergy) {
+      tinyMaterial.uniforms.uAudioEnergy.value = audioState.metrics.energy;
+    }
+    if (tinyMaterial.uniforms.uAudioWave) {
+      tinyMaterial.uniforms.uAudioWave.value = audioState.metrics.wave;
+    }
+    const waveContribution = modifiers.size ? audioState.metrics.wave : 0;
+    const tinySize = params.sizeFactorTiny * Math.max(0.05, 0.8 + sizeBoost * 0.2 + waveContribution * 0.35);
+    if (tinyMaterial.uniforms.uSize) {
+      tinyMaterial.uniforms.uSize.value = tinySize;
+    }
+    if (tinyMaterial.uniforms.uAlpha) {
+      const baseTinyAlpha = params.tinyAlpha;
+      const alphaBoost = modifiers.alpha ? audioState.visual.alpha : AUDIO_VISUAL_BASE.alpha;
+      const boostedTinyAlpha = Math.min(1, baseTinyAlpha + alphaBoost * 0.4);
+      tinyMaterial.uniforms.uAlpha.value = boostedTinyAlpha;
+    }
+    if (tinyMaterial.uniforms.uColor) {
+      tinyMaterial.uniforms.uColor.value.copy(audioState.color);
+    }
+  }
+}
+
+function applyAudioMotion(delta, modifiers = audioState.modifiers || {}) {
+  const extraRotation = modifiers.motion ? audioState.visual.motion : AUDIO_VISUAL_BASE.motion;
+  if (extraRotation > 1e-4) {
+    const yaw = extraRotation * delta * 0.85;
+    const pitch = (modifiers.motion ? audioState.metrics.wave : 0) * delta * 0.35;
+    if (Number.isFinite(yaw) && Math.abs(yaw) < Math.PI) {
+      clusterGroup.rotateY(yaw);
+    }
+    if (Number.isFinite(pitch) && Math.abs(pitch) < Math.PI) {
+      clusterGroup.rotateX(pitch);
+    }
+  }
+}
+
+function resetAudioReactivity() {
+  resetAudioMetrics();
+  applyAudioVisualState();
+}
+
 function isAudioSupported() {
   return !!AudioContextClass;
 }
@@ -874,6 +973,7 @@ function stopAudioPlayback({ suspendContext = false } = {}) {
   audioState.playing = false;
   audioState.usingMic = false;
   disconnectAnalyser();
+  resetAudioReactivity();
   if (audioState.context && suspendContext && typeof audioState.context.suspend === 'function') {
     audioState.context.suspend().catch(() => {});
   }
@@ -897,6 +997,7 @@ function setAudioModifier(key, enabled) {
     audioState.visual[key] = AUDIO_VISUAL_BASE[key];
   }
   refreshAudioUI();
+  applyAudioVisualState();
 }
 
 function toggleAudioModifier(key) {
@@ -985,9 +1086,7 @@ async function playSelectedFile() {
     source.buffer = buffer;
     source.onended = () => {
       if (audioState.source === source) {
-        audioState.source = null;
-        disconnectAnalyser();
-        audioState.playing = false;
+        stopAudioPlayback();
         setAudioStatus('Wiedergabe beendet', 'idle');
         refreshAudioUI();
       }
@@ -1126,6 +1225,7 @@ function updateAudioReactive(delta) {
   const targetScale = Math.min(2.2, 1 + audioState.metrics.energy * 0.45 + audioState.metrics.wave * 0.35 + audioState.metrics.bass * 0.25);
   const targetHue = audioState.metrics.treble * 90;
   const targetAlpha = Math.min(0.5, audioState.metrics.energy * 0.35 + audioState.metrics.wave * 0.2);
+  const modifiers = audioState.modifiers || {};
 
   audioState.visual.motion = damp(audioState.visual.motion, modifiers.motion ? targetMotion : AUDIO_VISUAL_BASE.motion, 6, delta);
   audioState.visual.size = damp(audioState.visual.size, modifiers.size ? targetSize : AUDIO_VISUAL_BASE.size, 7, delta);
@@ -1137,95 +1237,8 @@ function updateAudioReactive(delta) {
 function applyAudioVisuals(delta) {
   updateAudioReactive(delta);
   const modifiers = audioState.modifiers || {};
-  const sizeBoost = modifiers.size ? audioState.visual.size : AUDIO_VISUAL_BASE.size;
-  const hueOffset = modifiers.hue ? audioState.visual.hue : AUDIO_VISUAL_BASE.hue;
-  const saturationBoost = modifiers.saturation ? audioState.metrics.treble * 0.18 : 0;
-  const brightnessBoost = modifiers.brightness ? audioState.metrics.energy * 0.25 : 0;
-  const hue = (params.pointHue + hueOffset) % 360;
-  const saturation = Math.min(1, params.pointSaturation + saturationBoost);
-  const brightness = Math.min(1.1, params.pointValue + brightnessBoost);
-  const reactiveColor = hsv2rgb(hue, saturation, brightness);
-  audioState.color.copy(reactiveColor);
-
-  const targetScale = modifiers.scale ? audioState.visual.scale : AUDIO_VISUAL_BASE.scale;
-  const sphereScale = Math.max(0.35, Math.min(2.2, targetScale));
-  if (Number.isFinite(sphereScale)) {
-    if (Math.abs(clusterGroup.scale.x - sphereScale) > 1e-4 ||
-        Math.abs(clusterGroup.scale.y - sphereScale) > 1e-4 ||
-        Math.abs(clusterGroup.scale.z - sphereScale) > 1e-4) {
-      clusterGroup.scale.setScalar(sphereScale);
-    }
-  }
-
-  audioBandVector.set(audioState.metrics.bass, audioState.metrics.mid, audioState.metrics.treble);
-
-  if (starMaterial && starMaterial.uniforms) {
-    if (starMaterial.uniforms.uAudioBands && starMaterial.uniforms.uAudioBands.value) {
-      starMaterial.uniforms.uAudioBands.value.copy(audioBandVector);
-    }
-    if (starMaterial.uniforms.uAudioEnergy) {
-      starMaterial.uniforms.uAudioEnergy.value = audioState.metrics.energy;
-    }
-    if (starMaterial.uniforms.uAudioWave) {
-      starMaterial.uniforms.uAudioWave.value = audioState.metrics.wave;
-    }
-    if (starMaterial.uniforms.uSizeFactorSmall) {
-      starMaterial.uniforms.uSizeFactorSmall.value = params.sizeFactorSmall * sizeBoost;
-    }
-    if (starMaterial.uniforms.uSizeFactorMedium) {
-      starMaterial.uniforms.uSizeFactorMedium.value = params.sizeFactorMedium * sizeBoost;
-    }
-    if (starMaterial.uniforms.uSizeFactorLarge) {
-      starMaterial.uniforms.uSizeFactorLarge.value = params.sizeFactorLarge * sizeBoost;
-    }
-    if (starMaterial.uniforms.uAlpha) {
-      const baseAlpha = params.pointAlpha;
-      const alphaBoost = modifiers.alpha ? audioState.visual.alpha : AUDIO_VISUAL_BASE.alpha;
-      const boostedAlpha = Math.max(0.05, Math.min(1, baseAlpha + alphaBoost));
-      starMaterial.uniforms.uAlpha.value = boostedAlpha;
-    }
-    if (starMaterial.uniforms.uColor) {
-      starMaterial.uniforms.uColor.value.copy(audioState.color);
-    }
-  }
-
-  if (tinyMaterial && tinyMaterial.uniforms) {
-    if (tinyMaterial.uniforms.uAudioBands && tinyMaterial.uniforms.uAudioBands.value) {
-      tinyMaterial.uniforms.uAudioBands.value.copy(audioBandVector);
-    }
-    if (tinyMaterial.uniforms.uAudioEnergy) {
-      tinyMaterial.uniforms.uAudioEnergy.value = audioState.metrics.energy;
-    }
-    if (tinyMaterial.uniforms.uAudioWave) {
-      tinyMaterial.uniforms.uAudioWave.value = audioState.metrics.wave;
-    }
-    const waveContribution = modifiers.size ? audioState.metrics.wave : 0;
-    const tinySize = params.sizeFactorTiny * Math.max(0.05, 0.8 + sizeBoost * 0.2 + waveContribution * 0.35);
-    if (tinyMaterial.uniforms.uSize) {
-      tinyMaterial.uniforms.uSize.value = tinySize;
-    }
-    if (tinyMaterial.uniforms.uAlpha) {
-      const baseTinyAlpha = params.tinyAlpha;
-      const alphaBoost = modifiers.alpha ? audioState.visual.alpha : AUDIO_VISUAL_BASE.alpha;
-      const boostedTinyAlpha = Math.min(1, baseTinyAlpha + alphaBoost * 0.4);
-      tinyMaterial.uniforms.uAlpha.value = boostedTinyAlpha;
-    }
-    if (tinyMaterial.uniforms.uColor) {
-      tinyMaterial.uniforms.uColor.value.copy(audioState.color);
-    }
-  }
-
-  const extraRotation = modifiers.motion ? audioState.visual.motion : AUDIO_VISUAL_BASE.motion;
-  if (extraRotation > 1e-4) {
-    const yaw = extraRotation * delta * 0.85;
-    const pitch = (modifiers.motion ? audioState.metrics.wave : 0) * delta * 0.35;
-    if (Number.isFinite(yaw) && Math.abs(yaw) < Math.PI) {
-      clusterGroup.rotateY(yaw);
-    }
-    if (Number.isFinite(pitch) && Math.abs(pitch) < Math.PI) {
-      clusterGroup.rotateX(pitch);
-    }
-  }
+  applyAudioVisualState(modifiers);
+  applyAudioMotion(delta, modifiers);
 }
 
 /* Globals for stars and tiny connections */
@@ -3073,6 +3086,7 @@ setCameraLocked(false);
 updatePointColor(false);
 setSliders();
 rebuildStars();
+applyAudioVisualState();
 requestAnimationFrame(animate);
 </script>
 </body>


### PR DESCRIPTION
## Summary
- refactor audio reactivity updates into reusable helpers so controls can update the scene immediately
- reset audio metrics when playback stops and when modifiers change to keep the visualization in sync with UI choices
- apply the current audio modifier state after initialization and whenever state changes for consistent visuals

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dfe0c5834483248b1c2151414d796c