### PR TITLE
Fix missing audio intensity helpers to restore rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -862,6 +862,63 @@ const audioUI = {
   intensityControls: null
 };
 
+function clampIntensityPercent(value, fallback = 100) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return Math.max(0, Math.min(200, Math.round(fallback)));
+  }
+  const rounded = Math.round(numeric / 5) * 5;
+  return Math.max(0, Math.min(200, rounded));
+}
+
+function getAudioIntensity(key) {
+  if (!key || !audioState || !audioState.intensity) {
+    return 1;
+  }
+  if (!(key in audioState.intensity)) {
+    const fallback = (key in AUDIO_INTENSITY_DEFAULTS) ? AUDIO_INTENSITY_DEFAULTS[key] : 1;
+    audioState.intensity[key] = Number.isFinite(fallback) ? fallback : 1;
+  }
+  const current = audioState.intensity[key];
+  return Number.isFinite(current) ? Math.max(0, current) : 1;
+}
+
+function syncAudioIntensityControls() {
+  if (!audioUI.intensityControls || typeof audioUI.intensityControls.forEach !== 'function') {
+    return;
+  }
+  const modifiers = audioState.modifiers || {};
+  audioUI.intensityControls.forEach(({ input, valueEl, container }, key) => {
+    const percent = clampIntensityPercent(getAudioIntensity(key) * 100);
+    if (input) {
+      if (document.activeElement !== input) {
+        input.value = String(percent);
+      }
+      input.setAttribute('aria-valuenow', String(percent));
+    }
+    if (valueEl) {
+      valueEl.textContent = `${percent}%`;
+    }
+    if (container) {
+      const enabled = modifiers[key] !== false;
+      container.classList.toggle('is-disabled', !enabled);
+    }
+  });
+}
+
+function setAudioIntensity(key, percentValue) {
+  if (!key || !(key in AUDIO_INTENSITY_DEFAULTS)) {
+    return;
+  }
+  const clampedPercent = clampIntensityPercent(percentValue, AUDIO_INTENSITY_DEFAULTS[key] * 100);
+  if (!audioState.intensity) {
+    audioState.intensity = { ...AUDIO_INTENSITY_DEFAULTS };
+  }
+  audioState.intensity[key] = clampedPercent / 100;
+  syncAudioIntensityControls();
+  applyAudioVisualState();
+}
+
 const audioBandVector = new THREE.Vector3();
 
 function applyAudioVisualState(modifiers = audioState.modifiers || {}) {


### PR DESCRIPTION
## Summary
- add audio intensity helper functions so the UI can initialise without runtime errors
- restore scene setup so the volumetric point cloud renders again on load

## Testing
- browser_container.run_playwright_script (chromium smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68dfefaabc20832480edbe28cd6f0c5d