### PR TITLE
Fix volumetric rendering regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -1111,7 +1111,6 @@ const colorState = {
   radius: params.radius
 };
 const COLOR_MODES = ['uniform', 'radialPulse', 'axisWave', 'phaseFlicker', 'randomHue'];
-const COLOR_MODES = ['uniform', 'radialPulse', 'axisWave', 'phaseFlicker'];
 const MOTION_MODES = ['static', 'sine', 'noise', 'orbit'];
 const motionState = { time: 0 };
 
@@ -2153,21 +2152,6 @@ function makeStars() {
         rndHSV.z = clamp(rndHSV.z * (0.7 + 0.3 * (randC * 0.5 + 0.5)), 0.0, 1.2);
         vec3 randomColor = hsv2rgb(rndHSV);
         return mix(baseColor, randomColor, intensity);
-    vec3 computeColor() {
-      if (uColorMode < 0.5) {
-        return uColor;
-      } else if (uColorMode < 1.5) {
-        float norm = uColorRadius > 1e-4 ? clamp(vRadius / uColorRadius, 0.0, 1.0) : 0.0;
-        float pulse = 0.5 + 0.5 * sin(uTime * 2.2 + norm * 6.2831853 + vPhase * 3.1415926);
-        return mix(uColor, uColorAccent, pulse);
-      } else if (uColorMode < 2.5) {
-        float axis = clamp((vBase.y / max(uColorRadius, 1e-4)) * 0.5 + 0.5, 0.0, 1.0);
-        float sweep = 0.5 + 0.5 * sin(uTime * 1.4 + axis * 6.2831853);
-        return mix(uColorDim, uColorAccent, sweep);
-      } else {
-        float flicker = fract(sin(vPhase * 43758.5453 + uTime * 0.45) * 43758.5453);
-        float mixAmt = smoothstep(0.2, 0.8, flicker);
-        return mix(uColorDim, uColorAccent, mixAmt);
       }
     }
 
@@ -2212,8 +2196,7 @@ function makeStars() {
       uColorRadius: { value: colorState.radius },
       uColorIntensity: { value: params.colorIntensity },
       uColorSpeed: { value: params.colorSpeed },
-      uHueSpread: { value: params.hueSpread }
-      uColorRadius: { value: colorState.radius }
+      uHueSpread: { value: params.hueSpread },
     }
   });
   starMaterial.blending = (params.blending === 'Additive') ? THREE.AdditiveBlending : THREE.NormalBlending;
@@ -2455,21 +2438,6 @@ function makeTiny() {
         rndHSV.z = clamp(rndHSV.z * (0.7 + 0.3 * (randC * 0.5 + 0.5)), 0.0, 1.2);
         vec3 randomColor = hsv2rgb(rndHSV);
         return mix(baseColor, randomColor, intensity);
-    vec3 computeColor() {
-      if (uColorMode < 0.5) {
-        return uColor;
-      } else if (uColorMode < 1.5) {
-        float norm = uColorRadius > 1e-4 ? clamp(vRadius / uColorRadius, 0.0, 1.0) : 0.0;
-        float pulse = 0.5 + 0.5 * sin(uTime * 2.8 + norm * 6.2831853 + vPhase * 4.7123889);
-        return mix(uColor, uColorAccent, pulse);
-      } else if (uColorMode < 2.5) {
-        float axis = clamp((vBase.y / max(uColorRadius, 1e-4)) * 0.5 + 0.5, 0.0, 1.0);
-        float sweep = 0.5 + 0.5 * sin(uTime * 1.8 + axis * 6.2831853);
-        return mix(uColorDim, uColorAccent, sweep);
-      } else {
-        float flicker = fract(sin(vPhase * 43758.5453 + uTime * 0.6) * 43758.5453);
-        float mixAmt = smoothstep(0.15, 0.85, flicker);
-        return mix(uColorDim, uColorAccent, mixAmt);
       }
     }
 
@@ -2507,8 +2475,7 @@ function makeTiny() {
       uColorRadius: { value: colorState.radius },
       uColorIntensity: { value: params.colorIntensity },
       uColorSpeed: { value: params.colorSpeed },
-      uHueSpread: { value: params.hueSpread }
-      uColorRadius: { value: colorState.radius }
+      uHueSpread: { value: params.hueSpread },
     }
   });
   tinyMaterial.blending = (params.blending === 'Additive') ? THREE.AdditiveBlending : THREE.NormalBlending;


### PR DESCRIPTION
## Summary
- remove merge leftovers that redeclared color mode constants and duplicated shader code, which prevented the scene from rendering
- restore the shader computeColor logic including the random hue mode and clean uniform definitions for both star and tiny materials

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e022d0e1508324b2a8c12d0cadbb0c