### PR TITLE
Add STL upload support and center Feldappen view

### DIFF
--- a/STLLoader.js
+++ b/STLLoader.js
@@ -1,0 +1,415 @@
+( function ( THREE ) {
+
+	const {
+		BufferAttribute,
+		BufferGeometry,
+		Color,
+		FileLoader,
+		Float32BufferAttribute,
+		Loader,
+		Vector3
+	} = THREE;
+
+
+	/**
+ * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.
+ *
+ * Supports both binary and ASCII encoded files, with automatic detection of type.
+ *
+ * The loader returns a non-indexed buffer geometry.
+ *
+ * Limitations:
+ *  Binary decoding supports "Magics" color format (http://en.wikipedia.org/wiki/STL_(file_format)#Color_in_binary_STL).
+ *  There is perhaps some question as to how valid it is to always assume little-endian-ness.
+ *  ASCII decoding assumes file is UTF-8.
+ *
+ * Usage:
+ *  const loader = new STLLoader();
+ *  loader.load( './models/stl/slotted_disk.stl', function ( geometry ) {
+ *    scene.add( new THREE.Mesh( geometry ) );
+ *  });
+ *
+ * For binary STLs geometry might contain colors for vertices. To use it:
+ *  // use the same code to load STL as above
+ *  if (geometry.hasColors) {
+ *    material = new THREE.MeshPhongMaterial({ opacity: geometry.alpha, vertexColors: true });
+ *  } else { .... }
+ *  const mesh = new THREE.Mesh( geometry, material );
+ *
+ * For ASCII STLs containing multiple solids, each solid is assigned to a different group.
+ * Groups can be used to assign a different color by defining an array of materials with the same length of
+ * geometry.groups and passing it to the Mesh constructor:
+ *
+ * const mesh = new THREE.Mesh( geometry, material );
+ *
+ * For example:
+ *
+ *  const materials = [];
+ *  const nGeometryGroups = geometry.groups.length;
+ *
+ *  const colorMap = ...; // Some logic to index colors.
+ *
+ *  for (let i = 0; i < nGeometryGroups; i++) {
+ *
+ *		const material = new THREE.MeshPhongMaterial({
+ *			color: colorMap[i],
+ *			wireframe: false
+ *		});
+ *
+ *  }
+ *
+ *  materials.push(material);
+ *  const mesh = new THREE.Mesh(geometry, materials);
+ */
+
+
+class STLLoader extends Loader {
+
+	constructor( manager ) {
+
+		super( manager );
+
+	}
+
+	load( url, onLoad, onProgress, onError ) {
+
+		const scope = this;
+
+		const loader = new FileLoader( this.manager );
+		loader.setPath( this.path );
+		loader.setResponseType( 'arraybuffer' );
+		loader.setRequestHeader( this.requestHeader );
+		loader.setWithCredentials( this.withCredentials );
+
+		loader.load( url, function ( text ) {
+
+			try {
+
+				onLoad( scope.parse( text ) );
+
+			} catch ( e ) {
+
+				if ( onError ) {
+
+					onError( e );
+
+				} else {
+
+					console.error( e );
+
+				}
+
+				scope.manager.itemError( url );
+
+			}
+
+		}, onProgress, onError );
+
+	}
+
+	parse( data ) {
+
+		function isBinary( data ) {
+
+			const reader = new DataView( data );
+			const face_size = ( 32 / 8 * 3 ) + ( ( 32 / 8 * 3 ) * 3 ) + ( 16 / 8 );
+			const n_faces = reader.getUint32( 80, true );
+			const expect = 80 + ( 32 / 8 ) + ( n_faces * face_size );
+
+			if ( expect === reader.byteLength ) {
+
+				return true;
+
+			}
+
+			// An ASCII STL data must begin with 'solid ' as the first six bytes.
+			// However, ASCII STLs lacking the SPACE after the 'd' are known to be
+			// plentiful.  So, check the first 5 bytes for 'solid'.
+
+			// Several encodings, such as UTF-8, precede the text with up to 5 bytes:
+			// https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
+			// Search for "solid" to start anywhere after those prefixes.
+
+			// US-ASCII ordinal values for 's', 'o', 'l', 'i', 'd'
+
+			const solid = [ 115, 111, 108, 105, 100 ];
+
+			for ( let off = 0; off < 5; off ++ ) {
+
+				// If "solid" text is matched to the current offset, declare it to be an ASCII STL.
+
+				if ( matchDataViewAt( solid, reader, off ) ) return false;
+
+			}
+
+			// Couldn't find "solid" text at the beginning; it is binary STL.
+
+			return true;
+
+		}
+
+		function matchDataViewAt( query, reader, offset ) {
+
+			// Check if each byte in query matches the corresponding byte from the current offset
+
+			for ( let i = 0, il = query.length; i < il; i ++ ) {
+
+				if ( query[ i ] !== reader.getUint8( offset + i ) ) return false;
+
+			}
+
+			return true;
+
+		}
+
+		function parseBinary( data ) {
+
+			const reader = new DataView( data );
+			const faces = reader.getUint32( 80, true );
+
+			let r, g, b, hasColors = false, colors;
+			let defaultR, defaultG, defaultB, alpha;
+
+			// process STL header
+			// check for default color in header ("COLOR=rgba" sequence).
+
+			for ( let index = 0; index < 80 - 10; index ++ ) {
+
+				if ( ( reader.getUint32( index, false ) == 0x434F4C4F /*COLO*/ ) &&
+					( reader.getUint8( index + 4 ) == 0x52 /*'R'*/ ) &&
+					( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
+
+					hasColors = true;
+					colors = new Float32Array( faces * 3 * 3 );
+
+					defaultR = reader.getUint8( index + 6 ) / 255;
+					defaultG = reader.getUint8( index + 7 ) / 255;
+					defaultB = reader.getUint8( index + 8 ) / 255;
+					alpha = reader.getUint8( index + 9 ) / 255;
+
+				}
+
+			}
+
+			const dataOffset = 84;
+			const faceLength = 12 * 4 + 2;
+
+			const geometry = new BufferGeometry();
+
+			const vertices = new Float32Array( faces * 3 * 3 );
+			const normals = new Float32Array( faces * 3 * 3 );
+
+			const color = new Color();
+
+			for ( let face = 0; face < faces; face ++ ) {
+
+				const start = dataOffset + face * faceLength;
+				const normalX = reader.getFloat32( start, true );
+				const normalY = reader.getFloat32( start + 4, true );
+				const normalZ = reader.getFloat32( start + 8, true );
+
+				if ( hasColors ) {
+
+					const packedColor = reader.getUint16( start + 48, true );
+
+					if ( ( packedColor & 0x8000 ) === 0 ) {
+
+						// facet has its own unique color
+
+						r = ( packedColor & 0x1F ) / 31;
+						g = ( ( packedColor >> 5 ) & 0x1F ) / 31;
+						b = ( ( packedColor >> 10 ) & 0x1F ) / 31;
+
+					} else {
+
+						r = defaultR;
+						g = defaultG;
+						b = defaultB;
+
+					}
+
+				}
+
+				for ( let i = 1; i <= 3; i ++ ) {
+
+					const vertexstart = start + i * 12;
+					const componentIdx = ( face * 3 * 3 ) + ( ( i - 1 ) * 3 );
+
+					vertices[ componentIdx ] = reader.getFloat32( vertexstart, true );
+					vertices[ componentIdx + 1 ] = reader.getFloat32( vertexstart + 4, true );
+					vertices[ componentIdx + 2 ] = reader.getFloat32( vertexstart + 8, true );
+
+					normals[ componentIdx ] = normalX;
+					normals[ componentIdx + 1 ] = normalY;
+					normals[ componentIdx + 2 ] = normalZ;
+
+					if ( hasColors ) {
+
+						color.set( r, g, b ).convertSRGBToLinear();
+
+						colors[ componentIdx ] = color.r;
+						colors[ componentIdx + 1 ] = color.g;
+						colors[ componentIdx + 2 ] = color.b;
+
+					}
+
+				}
+
+			}
+
+			geometry.setAttribute( 'position', new BufferAttribute( vertices, 3 ) );
+			geometry.setAttribute( 'normal', new BufferAttribute( normals, 3 ) );
+
+			if ( hasColors ) {
+
+				geometry.setAttribute( 'color', new BufferAttribute( colors, 3 ) );
+				geometry.hasColors = true;
+				geometry.alpha = alpha;
+
+			}
+
+			return geometry;
+
+		}
+
+		function parseASCII( data ) {
+
+			const geometry = new BufferGeometry();
+			const patternSolid = /solid([\s\S]*?)endsolid/g;
+			const patternFace = /facet([\s\S]*?)endfacet/g;
+			const patternName = /solid\s(.+)/;
+			let faceCounter = 0;
+
+			const patternFloat = /[\s]+([+-]?(?:\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?)/.source;
+			const patternVertex = new RegExp( 'vertex' + patternFloat + patternFloat + patternFloat, 'g' );
+			const patternNormal = new RegExp( 'normal' + patternFloat + patternFloat + patternFloat, 'g' );
+
+			const vertices = [];
+			const normals = [];
+			const groupNames = [];
+
+			const normal = new Vector3();
+
+			let result;
+
+			let groupCount = 0;
+			let startVertex = 0;
+			let endVertex = 0;
+
+			while ( ( result = patternSolid.exec( data ) ) !== null ) {
+
+				startVertex = endVertex;
+
+				const solid = result[ 0 ];
+
+				const name = ( result = patternName.exec( solid ) ) !== null ? result[ 1 ] : '';
+				groupNames.push( name );
+
+				while ( ( result = patternFace.exec( solid ) ) !== null ) {
+
+					let vertexCountPerFace = 0;
+					let normalCountPerFace = 0;
+
+					const text = result[ 0 ];
+
+					while ( ( result = patternNormal.exec( text ) ) !== null ) {
+
+						normal.x = parseFloat( result[ 1 ] );
+						normal.y = parseFloat( result[ 2 ] );
+						normal.z = parseFloat( result[ 3 ] );
+						normalCountPerFace ++;
+
+					}
+
+					while ( ( result = patternVertex.exec( text ) ) !== null ) {
+
+						vertices.push( parseFloat( result[ 1 ] ), parseFloat( result[ 2 ] ), parseFloat( result[ 3 ] ) );
+						normals.push( normal.x, normal.y, normal.z );
+						vertexCountPerFace ++;
+						endVertex ++;
+
+					}
+
+					// every face have to own ONE valid normal
+
+					if ( normalCountPerFace !== 1 ) {
+
+						console.error( 'THREE.STLLoader: Something isn\'t right with the normal of face number ' + faceCounter );
+
+					}
+
+					// each face have to own THREE valid vertices
+
+					if ( vertexCountPerFace !== 3 ) {
+
+						console.error( 'THREE.STLLoader: Something isn\'t right with the vertices of face number ' + faceCounter );
+
+					}
+
+					faceCounter ++;
+
+				}
+
+				const start = startVertex;
+				const count = endVertex - startVertex;
+
+				geometry.userData.groupNames = groupNames;
+
+				geometry.addGroup( start, count, groupCount );
+				groupCount ++;
+
+			}
+
+			geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+			geometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+
+			return geometry;
+
+		}
+
+		function ensureString( buffer ) {
+
+			if ( typeof buffer !== 'string' ) {
+
+				return new TextDecoder().decode( buffer );
+
+			}
+
+			return buffer;
+
+		}
+
+		function ensureBinary( buffer ) {
+
+			if ( typeof buffer === 'string' ) {
+
+				const array_buffer = new Uint8Array( buffer.length );
+				for ( let i = 0; i < buffer.length; i ++ ) {
+
+					array_buffer[ i ] = buffer.charCodeAt( i ) & 0xff; // implicitly assumes little-endian
+
+				}
+
+				return array_buffer.buffer || array_buffer;
+
+			} else {
+
+				return buffer;
+
+			}
+
+		}
+
+		// start
+
+		const binData = ensureBinary( data );
+
+		return isBinary( binData ) ? parseBinary( binData ) : parseASCII( ensureString( data ) );
+
+	}
+
+}
+
+	THREE.STLLoader = STLLoader;
+
+} )( THREE );

--- a/index.html
+++ b/index.html
@@ -503,6 +503,7 @@
   <!-- Load Three.js and OrbitControls from local files -->
   <script src="./three.min.js"></script>
   <script src="./OrbitControls.js"></script>
+  <script src="./STLLoader.js"></script>
 </head>
 <body>
 <div id="bar">
@@ -726,6 +727,24 @@
             <input id="pCatLargeCount" type="number" min="0" step="1" />
             <div class="val" id="vCatLargeCount"></div>
           </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section class="accordion" id="acc-volume">
+    <button type="button" class="accordion__trigger" id="acc-volume-trigger" aria-expanded="false" aria-controls="acc-volume-panel">
+      Volumenkörper
+    </button>
+    <div class="accordion__panel" id="acc-volume-panel" role="region" aria-labelledby="acc-volume-trigger" hidden>
+      <div class="row file-row">
+        <label for="stlFiles">STL-Modelle</label>
+        <input id="stlFiles" type="file" accept=".stl,model/stl,application/sla" multiple />
+        <div class="file-meta" id="stlFileMeta">Keine Auswahl</div>
+        <div class="hint">Lade eine oder mehrere STL-Dateien hoch, um sie zu einem Volumenkörper zu kombinieren.</div>
+      </div>
+      <div class="row">
+        <div class="wrap">
+          <button type="button" id="stlClear" disabled>🧹 Modelle entfernen</button>
         </div>
       </div>
     </div>
@@ -1193,6 +1212,47 @@ controls.zoomSpeed = 0.6;
 const clusterGroup = new THREE.Group();
 scene.add(clusterGroup);
 
+const FELDAPPEN_CENTER = new THREE.Vector3(0, 0, 0);
+
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.45);
+scene.add(ambientLight);
+
+const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
+directionalLight.position.set(220, 340, 260);
+directionalLight.target.position.copy(FELDAPPEN_CENTER);
+scene.add(directionalLight);
+scene.add(directionalLight.target);
+
+const stlGroup = new THREE.Group();
+stlGroup.name = 'feldappenVolume';
+stlGroup.visible = false;
+clusterGroup.add(stlGroup);
+
+const stlLoader = new THREE.STLLoader();
+const stlMaterial = new THREE.MeshPhongMaterial({
+  color: 0x5fa8ff,
+  specular: 0x1a1a1a,
+  shininess: 60,
+  transparent: true,
+  opacity: 0.85,
+  side: THREE.DoubleSide,
+  vertexColors: false
+});
+const stlState = {
+  files: [],
+  combinedMesh: null,
+  boundingRadius: 0
+};
+const stlUI = {
+  input: null,
+  meta: null,
+  clearBtn: null
+};
+
+clusterGroup.position.copy(FELDAPPEN_CENTER);
+controls.target.copy(FELDAPPEN_CENTER);
+controls.update();
+
 /* Parameters */
 const params = {
   count: 2500,
@@ -1251,6 +1311,239 @@ const colorState = {
 const COLOR_MODES = ['uniform', 'radialPulse', 'axisWave', 'phaseFlicker', 'randomHue'];
 const MOTION_MODES = ['static', 'sine', 'noise', 'orbit'];
 const motionState = { time: 0 };
+
+function getFeldappenFocusRadius() {
+  const values = [
+    Number.isFinite(colorState.radius) ? colorState.radius : 0,
+    Number.isFinite(stlState.boundingRadius) ? stlState.boundingRadius : 0,
+    Number.isFinite(params.radius) ? params.radius : 0,
+    80
+  ];
+  return Math.max(...values);
+}
+
+function focusOnFeldappenCenter({ repositionCamera = true } = {}) {
+  const target = FELDAPPEN_CENTER;
+  controls.target.copy(target);
+  clusterGroup.position.copy(target);
+  if (repositionCamera) {
+    const distance = Math.max(getFeldappenFocusRadius() * 3.2, 320);
+    camera.position.set(target.x, target.y, target.z + distance);
+  }
+  controls.update();
+}
+
+function updateStlMeta(files = [], { loading = false, error = '' } = {}) {
+  const names = Array.isArray(files)
+    ? files.map(item => (typeof item === 'string' ? item : (item && item.name) || '')).filter(Boolean)
+    : [];
+  if (stlUI.meta) {
+    let text = 'Keine Auswahl';
+    let state = 'idle';
+    if (error) {
+      text = error;
+      state = 'error';
+    } else if (loading) {
+      text = 'Lade STL-Dateien …';
+      state = 'loading';
+    } else if (names.length) {
+      text = names.length === 1
+        ? `Geladen: ${names[0]}`
+        : `Geladen: ${names.length} STL-Dateien`;
+      state = 'ready';
+    }
+    stlUI.meta.textContent = text;
+    stlUI.meta.dataset.state = state;
+  }
+  if (stlUI.clearBtn) {
+    stlUI.clearBtn.disabled = loading || !stlState.combinedMesh;
+  }
+  if (stlUI.input) {
+    stlUI.input.disabled = loading;
+  }
+}
+
+function clearStlModels({ keepCamera = false, skipInputReset = false, preserveMeta = false } = {}) {
+  const hadMesh = Boolean(stlState.combinedMesh);
+  if (stlState.combinedMesh) {
+    if (stlState.combinedMesh.geometry) {
+      stlState.combinedMesh.geometry.dispose();
+    }
+    stlGroup.remove(stlState.combinedMesh);
+    stlState.combinedMesh = null;
+  }
+  stlGroup.visible = false;
+  stlState.files = [];
+  stlState.boundingRadius = 0;
+  if (!skipInputReset && stlUI.input) {
+    stlUI.input.value = '';
+  }
+  if (!preserveMeta) {
+    updateStlMeta([]);
+  } else if (stlUI.clearBtn) {
+    stlUI.clearBtn.disabled = true;
+  }
+  if (hadMesh && !keepCamera) {
+    focusOnFeldappenCenter({ repositionCamera: true });
+  }
+}
+
+function mergeStlGeometries(geometries) {
+  if (!Array.isArray(geometries) || !geometries.length) {
+    return null;
+  }
+  let totalVertices = 0;
+  let hasNormals = true;
+  let hasColors = false;
+  let alpha = 1;
+  geometries.forEach(geometry => {
+    if (!geometry || !geometry.getAttribute) {
+      return;
+    }
+    const position = geometry.getAttribute('position');
+    if (!position) {
+      return;
+    }
+    totalVertices += position.count;
+    if (!geometry.getAttribute('normal')) {
+      hasNormals = false;
+    }
+    if (geometry.hasColors && geometry.getAttribute('color')) {
+      hasColors = true;
+      if (typeof geometry.alpha === 'number') {
+        alpha = Math.min(alpha, geometry.alpha);
+      }
+    }
+  });
+  if (!Number.isFinite(totalVertices) || totalVertices <= 0) {
+    return null;
+  }
+  const merged = new THREE.BufferGeometry();
+  const positions = new Float32Array(totalVertices * 3);
+  const normals = hasNormals ? new Float32Array(totalVertices * 3) : null;
+  const colors = hasColors ? new Float32Array(totalVertices * 3) : null;
+  let vertexOffset = 0;
+  geometries.forEach(geometry => {
+    if (!geometry || !geometry.getAttribute) {
+      return;
+    }
+    const position = geometry.getAttribute('position');
+    if (!position) {
+      return;
+    }
+    positions.set(position.array, vertexOffset * 3);
+    if (hasNormals) {
+      const normal = geometry.getAttribute('normal');
+      if (normal && normal.count === position.count) {
+        normals.set(normal.array, vertexOffset * 3);
+      }
+    }
+    if (hasColors) {
+      const colorAttr = geometry.getAttribute('color');
+      if (colorAttr && colorAttr.count === position.count) {
+        colors.set(colorAttr.array, vertexOffset * 3);
+      }
+    }
+    vertexOffset += position.count;
+  });
+  merged.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  if (hasNormals && normals) {
+    merged.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+  } else {
+    merged.computeVertexNormals();
+  }
+  if (hasColors && colors) {
+    merged.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    merged.hasColors = true;
+    merged.alpha = alpha;
+  }
+  return merged;
+}
+
+function applyStlGeometry(geometry, fileNames = []) {
+  if (!(geometry instanceof THREE.BufferGeometry)) {
+    return;
+  }
+  if (stlState.combinedMesh) {
+    clearStlModels({ keepCamera: true, skipInputReset: true, preserveMeta: true });
+  }
+  geometry.computeBoundingBox();
+  if (geometry.boundingBox) {
+    const center = new THREE.Vector3();
+    geometry.boundingBox.getCenter(center);
+    geometry.translate(-center.x, -center.y, -center.z);
+  }
+  geometry.computeBoundingSphere();
+  const radius = geometry.boundingSphere ? geometry.boundingSphere.radius : 0;
+  stlState.boundingRadius = Number.isFinite(radius) ? Math.max(0, radius) : 0;
+  stlState.files = Array.isArray(fileNames) ? fileNames : [];
+  const hasColors = geometry.hasColors === true && geometry.getAttribute && geometry.getAttribute('color');
+  stlMaterial.vertexColors = Boolean(hasColors);
+  const alpha = hasColors && typeof geometry.alpha === 'number' ? geometry.alpha : stlMaterial.opacity;
+  const clampedAlpha = Math.max(0.2, Math.min(1, Number(alpha) || stlMaterial.opacity));
+  stlMaterial.opacity = clampedAlpha;
+  stlMaterial.transparent = clampedAlpha < 1;
+  stlMaterial.needsUpdate = true;
+  const mesh = new THREE.Mesh(geometry, stlMaterial);
+  mesh.name = 'feldappenVolumeMesh';
+  stlGroup.add(mesh);
+  stlGroup.position.copy(FELDAPPEN_CENTER);
+  stlGroup.visible = true;
+  stlState.combinedMesh = mesh;
+  if (stlUI.clearBtn) {
+    stlUI.clearBtn.disabled = false;
+  }
+  focusOnFeldappenCenter({ repositionCamera: true });
+}
+
+async function loadStlFilesFromInput(files) {
+  const selection = Array.isArray(files) ? files.filter(Boolean) : [];
+  if (!selection.length) {
+    clearStlModels();
+    return;
+  }
+  updateStlMeta(selection, { loading: true });
+  try {
+    const geometries = [];
+    for (const file of selection) {
+      const buffer = await file.arrayBuffer();
+      let geometry = stlLoader.parse(buffer);
+      if (!geometry) {
+        continue;
+      }
+      if (geometry.index) {
+        const nonIndexed = geometry.toNonIndexed();
+        geometry.dispose();
+        geometry = nonIndexed;
+      }
+      geometry.computeVertexNormals();
+      geometries.push(geometry);
+    }
+    if (!geometries.length) {
+      throw new Error('Keine gültigen STL-Geometrien gefunden.');
+    }
+    const merged = mergeStlGeometries(geometries);
+    geometries.forEach(geometry => geometry.dispose());
+    if (!merged) {
+      throw new Error('Geometrien konnten nicht kombiniert werden.');
+    }
+    merged.computeVertexNormals();
+    merged.computeBoundingBox();
+    merged.computeBoundingSphere();
+    const names = selection.map(file => (file && file.name) ? file.name : 'STL-Datei');
+    applyStlGeometry(merged, names);
+    updateStlMeta(names);
+  } catch (error) {
+    console.error('STL-Dateien konnten nicht geladen werden:', error);
+    updateStlMeta([], { error: 'Fehler beim Laden der STL-Dateien.' });
+    clearStlModels({ keepCamera: true, skipInputReset: true, preserveMeta: true });
+  } finally {
+    if (stlUI.input) {
+      stlUI.input.disabled = false;
+      stlUI.input.value = '';
+    }
+  }
+}
 
 function getMotionModeIndex() {
   const idx = MOTION_MODES.indexOf(params.motionMode);
@@ -2408,7 +2701,7 @@ function playCurrentTrack() {
   return true;
 }
 
-async function startRandomPlaylistPlayback() {
+async function startFirstPlaylistPlayback() {
   try {
     await ensurePresetPlaylistInitialized();
   } catch (error) {
@@ -2420,8 +2713,7 @@ async function startRandomPlaylistPlayback() {
     refreshAudioUI();
     return false;
   }
-  const randomIndex = Math.floor(Math.random() * total);
-  if (!setCurrentTrack(randomIndex)) {
+  if (!setCurrentTrack(0)) {
     return false;
   }
   await playSelectedFile();
@@ -3795,6 +4087,26 @@ audioUI.overlay = $('audioOverlay');
 audioUI.overlayButton = $('audioOverlayButton');
 audioUI.brightnessAdaptationBtn = $('brightnessAdaptationToggle');
 
+stlUI.input = $('stlFiles');
+stlUI.meta = $('stlFileMeta');
+stlUI.clearBtn = $('stlClear');
+
+if (stlUI.input) {
+  stlUI.input.addEventListener('change', event => {
+    const files = event.target.files ? Array.from(event.target.files).filter(Boolean) : [];
+    loadStlFilesFromInput(files).catch(error => {
+      console.error('Fehler beim Verarbeiten der STL-Auswahl:', error);
+      updateStlMeta([], { error: 'Fehler beim Laden der STL-Dateien.' });
+    });
+  });
+}
+if (stlUI.clearBtn) {
+  stlUI.clearBtn.addEventListener('click', () => {
+    clearStlModels();
+  });
+}
+updateStlMeta([]);
+
 if (audioUI.toggle && audioUI.body) {
   audioUI.toggle.addEventListener('click', () => {
     const expanded = audioUI.toggle.getAttribute('aria-expanded') === 'true';
@@ -4012,7 +4324,7 @@ if (audioUI.overlayButton) {
     if (audioUI.overlayButton.disabled) return;
     audioUI.overlayButton.disabled = true;
     audioUI.overlayButton.setAttribute('aria-busy', 'true');
-    const started = await startRandomPlaylistPlayback();
+    const started = await startFirstPlaylistPlayback();
     if (!started && shouldShowAudioOverlay()) {
       audioUI.overlayButton.disabled = false;
     }
@@ -5437,6 +5749,7 @@ setCameraLocked(false);
 updatePointColor(false);
 setSliders();
 rebuildStars();
+focusOnFeldappenCenter({ repositionCamera: true });
 applyAudioVisualState();
 requestAnimationFrame(animate);
 </script>


### PR DESCRIPTION
## Summary
- add a "Volumenkörper" section that accepts STL uploads, merges them into one mesh, and wires the loader into the scene
- focus the camera on the Feldappen center on load, add lighting for solid meshes, and expose the STL loader locally
- change the audio overlay button to start the first playlist track instead of a random one

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e07b3ce57883248065714dcafb8865