### PR TITLE
fix: show audio overlay after playlist load

### DIFF
--- a/index.html
+++ b/index.html
@@ -3119,7 +3119,7 @@ async function initializePresetPlaylist() {
   const files = descriptors.map(descriptor => new PresetAudioFile(descriptor));
   setPlaylist(files);
   const label = files.length === 1 ? (files[0].name || 'Audio-Datei') : `${files.length} Titel`;
-  setAudioStatus(`Preset-Playlist geladen – ${label}`, 'waiting');
+  setAudioStatus(`Preset-Playlist geladen – ${label}`, 'idle');
   refreshAudioUI();
 }
 
@@ -5120,7 +5120,7 @@ if (audioUI.fileInput) {
       const label = files.length === 1
         ? (files[0].name || 'Audio-Datei')
         : `${files.length} Titel`;
-      setAudioStatus(`Playlist geladen – ${label}`, 'waiting');
+      setAudioStatus(`Playlist geladen – ${label}`, 'idle');
     } else if (!audioState.playing) {
       setAudioStatus('Audio-Reaktivität inaktiv', 'idle');
     }


### PR DESCRIPTION
## Summary
- ensure the preset playlist status keeps the start overlay visible by using the idle state
- align manual playlist loading status with the idle state so the play overlay is immediately accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0d46b3b6c832494f340bc5a2743f4