### PR TITLE
Fix default editing mode regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@
 <div id="barHotspot" aria-hidden="true"></div>
 <div id="bar" role="toolbar" aria-hidden="true">
   <button id="toggle" aria-expanded="true">↕ Panels ausblenden</button>
-  <button id="editMode" aria-pressed="true">🛠️ Bearbeitungsmodus an</button>
+  <button id="editMode" aria-pressed="false">🛠️ Bearbeitungsmodus aus</button>
   <button id="lock" aria-pressed="false">🔓 Kamera frei</button>
   <button id="random">🎲 Random</button>
 </div>
@@ -7044,7 +7044,13 @@ setAutoRotation(false);
 recalculateSheetMetrics();
 const initialPanelVisible = false;
 setPanelVisible(initialPanelVisible);
-setEditingMode(true, { skipStop: true });
+const urlParams = new URLSearchParams(window.location.search);
+const startInEditingMode = urlParams.get('edit') === '1' || window.location.hash.includes('edit');
+if (startInEditingMode) {
+  setEditingMode(true, { skipStop: true });
+} else {
+  updateEditModeButton();
+}
 setCameraLocked(false);
 updatePointColor(false);
 setSliders();


### PR DESCRIPTION
## Summary
- show the interface with the editing mode turned off by default so the play overlay can appear
- refresh the editing-mode toggle label for the default state and allow opting into edit mode via ?edit=1 or #edit

## Testing
- python3 -m http.server 8000
- browser_container.run_playwright_script

------
https://chatgpt.com/codex/tasks/task_e_68e0e270f01083249c8c4eb01539a3e3