### PR TITLE
Fix playback overlay regression caused by edit mode initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -5057,6 +5057,20 @@ const barState = {
   hideTimeout: null,
 };
 
+let panelVisible = false;
+let audioPanelVisible = false;
+let cameraLocked = false;
+const experienceState = {
+  started: false,
+  panelsHiddenForPlayback: false,
+  previousPanelVisible: null,
+  previousBarVisible: null,
+  pendingOverlayStart: false,
+  editingMode: false,
+  editingPreviousPanel: null,
+  editingPreviousBar: null
+};
+
 if (barButtons.length) {
   barButtons.forEach(button => {
     const existing = button.getAttribute('tabindex');
@@ -5532,19 +5546,6 @@ if (audioUI.fileMeta || audioUI.playlistMeta) {
 setAudioStatus('Audio-Reaktivität inaktiv', 'idle');
 refreshAudioUI();
 presetPlaylistPromise = ensurePresetPlaylistInitialized();
-let panelVisible = false;
-let audioPanelVisible = false;
-let cameraLocked = false;
-const experienceState = {
-  started: false,
-  panelsHiddenForPlayback: false,
-  previousPanelVisible: null,
-  previousBarVisible: null,
-  pendingOverlayStart: false,
-  editingMode: false,
-  editingPreviousPanel: null,
-  editingPreviousBar: null
-};
 
 function isMobileSheetActive() {
   return mobileSheetQuery.matches;


### PR DESCRIPTION
## Summary
- initialize panel visibility flags and the editing state before any UI helpers run
- prevent temporal-dead-zone errors so the playback overlay renders and controls stay interactive on load

## Testing
- Manual verification in Chromium (Playwright) that the overlay appears and UI interactions are responsive

------
https://chatgpt.com/codex/tasks/task_e_68e0fe1fc0f88324b1411ee51786a311