### PR TITLE
Enable auto random mode on first playback start

### DIFF
--- a/index.html
+++ b/index.html
@@ -5872,6 +5872,10 @@ function notifyPlaybackStarted() {
   if (experienceState.editingMode) {
     setEditingMode(false, { skipStop: true, skipPanelRestore: true });
   }
+  const wasStarted = experienceState.started;
+  if (!wasStarted && !audioState.usingMic && !autoRandomState.enabled) {
+    setAutoRandomEnabled(true);
+  }
   hideInterfaceForPlayback({ remember: true });
   experienceState.started = true;
   experienceState.pendingOverlayStart = false;


### PR DESCRIPTION
## Summary
- automatically enable the random visuals mode when the first playlist playback begins so the initial play session shows randomised scenes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1139a3d2083249c22f36daa51ce80