### PR TITLE
Trigger auto random randomization on initial playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -5872,6 +5872,12 @@ function notifyPlaybackStarted() {
   if (experienceState.editingMode) {
     setEditingMode(false, { skipStop: true, skipPanelRestore: true });
   }
+  const wasStarted = experienceState.started;
+  const shouldAutoEnableRandom = !wasStarted && !audioState.usingMic && !autoRandomState.enabled;
+  if (shouldAutoEnableRandom) {
+    setAutoRandomEnabled(true);
+    randomizeParameters({ syncUI: true });
+  }
   hideInterfaceForPlayback({ remember: true });
   experienceState.started = true;
   experienceState.pendingOverlayStart = false;


### PR DESCRIPTION
## Summary
- auto-enable the random visuals mode on the first non-mic playback and immediately randomize parameters so visuals change right away

## Testing
- not run (manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68e1139a3d2083249c22f36daa51ce80