### PR TITLE
fix: ensure vite build works on GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   root: '.',
   publicDir: 'Musik',
+  base: './',
   server: {
     port: 5173,
     host: '0.0.0.0'


### PR DESCRIPTION
## Summary
- configure Vite to emit relative asset URLs so the bundle works when served from a sub-path such as GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e144c71f148324980e7b5c5f9b52c7