### PR TITLE
fix: initialize experience state before usage

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1113,6 +1113,17 @@ export function bootstrapApp() {
     nudgeInterval: 0.45
   };
 
+  const experienceState = {
+    started: false,
+    panelsHiddenForPlayback: false,
+    previousPanelVisible: null,
+    previousBarVisible: null,
+    pendingOverlayStart: false,
+    editingMode: false,
+    editingPreviousPanel: null,
+    editingPreviousBar: null,
+  };
+
   function clampIntensityPercent(value, fallback = 100, max = 200) {
     const numeric = Number(value);
     const limit = Number.isFinite(max) ? Math.max(0, max) : 200;
@@ -4204,16 +4215,6 @@ export function bootstrapApp() {
   let panelVisible = false;
   let audioPanelVisible = false;
   let cameraLocked = false;
-  const experienceState = {
-    started: false,
-    panelsHiddenForPlayback: false,
-    previousPanelVisible: null,
-    previousBarVisible: null,
-    pendingOverlayStart: false,
-    editingMode: false,
-    editingPreviousPanel: null,
-    editingPreviousBar: null
-  };
 
   function isMobileSheetActive() {
     return mobileSheetQuery.matches;

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   root: '.',
   publicDir: 'Musik',
+  base: './',
   server: {
     port: 5173,
     host: '0.0.0.0'


### PR DESCRIPTION
## Summary
- initialize the experience state before any audio overlay logic runs to avoid runtime errors during startup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e144c71f148324980e7b5c5f9b52c7