### PR TITLE
Fix mobile onboarding experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
     }
     html, body { margin: 0; height: 100%; overflow: hidden; background: #000; color: var(--fg); font-family: system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
     body { position: relative; }
+    body.is-preparing #panel,
+    body.is-preparing #panelHoverZone {
+      opacity: 0;
+      pointer-events: none;
+    }
+    body.is-preparing #panel {
+      transform: translate(-50%, 24px);
+      transition: none;
+    }
     :root {
       --panel-visible-height: 0px;
     }
@@ -526,6 +535,9 @@
       border: 0;
     }
     @media (max-width: 768px) {
+      body.is-preparing #panel {
+        transform: translateY(120%);
+      }
       #panel {
         width: 100%;
         left: 0;
@@ -535,13 +547,15 @@
         box-shadow: 0 -24px 40px rgba(0, 0, 0, 0.55);
       }
       #audioPanel {
-        position: fixed;
-        top: 64px;
+        position: static;
+        top: auto;
         bottom: auto;
-        left: 12px;
-        right: 12px;
-        width: auto;
+        left: auto;
+        right: auto;
+        width: 100%;
         max-width: none;
+        margin-top: 18px;
+        box-shadow: none;
       }
       #panel.is-hidden {
         transform: translateY(calc(var(--sheet-expanded-height, 80vh) + 40px));
@@ -586,6 +600,66 @@
     canvas:active { cursor: grabbing; }
     canvas.locked { cursor: not-allowed; }
     canvas.locked:active { cursor: not-allowed; }
+    .mobile-hint {
+      position: fixed;
+      left: 50%;
+      bottom: 72px;
+      transform: translate(-50%, 32px);
+      width: min(420px, calc(100vw - 32px));
+      padding: 16px 18px;
+      border-radius: 18px;
+      background: rgba(0, 0, 0, 0.78);
+      color: var(--fg);
+      box-shadow: 0 18px 46px rgba(0, 0, 0, 0.6);
+      z-index: 32;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s ease, transform .3s ease;
+    }
+    .mobile-hint[data-visible="true"] {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    .mobile-hint__content {
+      display: grid;
+      gap: .55rem;
+      text-align: center;
+      pointer-events: auto;
+    }
+    .mobile-hint__title {
+      margin: 0;
+      font-size: 1rem;
+      letter-spacing: .01em;
+    }
+    .mobile-hint__text {
+      margin: 0;
+      font-size: .9rem;
+      line-height: 1.4;
+      color: rgba(255, 255, 255, 0.82);
+    }
+    .mobile-hint__dismiss {
+      justify-self: center;
+      padding: .55rem 1.3rem;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.22);
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+      font-weight: 600;
+      font-size: .85rem;
+      letter-spacing: .01em;
+      cursor: pointer;
+      transition: background .2s ease, border-color .2s ease, transform .2s ease;
+    }
+    .mobile-hint__dismiss:hover,
+    .mobile-hint__dismiss:focus-visible {
+      background: rgba(90, 190, 255, 0.18);
+      border-color: rgba(90, 190, 255, 0.6);
+      outline: none;
+      transform: translateY(-1px);
+    }
+    @media (min-width: 769px) {
+      .mobile-hint { display: none; }
+    }
   </style>
   <!-- Load Three.js and OrbitControls from local files -->
   <script src="./three.min.js"></script>
@@ -593,7 +667,7 @@
   <script src="./STLLoader.js"></script>
   <script src="./OrbitControls.js"></script>
 </head>
-<body>
+<body class="is-preparing">
 <div id="sceneViewport" aria-label="Visualisierung"></div>
 <div id="panelHoverZone" aria-hidden="true"></div>
 <div id="panel">
@@ -1175,6 +1249,13 @@
     <div class="panel-footnote" id="audioSupportNotice">Nutze eine Datei oder das Mikrofon, um die Punktfarben an Audio zu koppeln.</div>
   </div>
 </div>
+<div id="mobileHint" class="mobile-hint" data-visible="false" aria-hidden="true" role="status">
+  <div class="mobile-hint__content">
+    <h3 class="mobile-hint__title">Steuerung öffnen</h3>
+    <p class="mobile-hint__text">Halte den Bildschirm gedrückt, um das Panel einzublenden und Einstellungen vorzunehmen.</p>
+    <button type="button" id="mobileHintDismiss" class="mobile-hint__dismiss">Alles klar</button>
+  </div>
+</div>
 <div id="audioOverlay" data-visible="false" aria-hidden="true">
   <button type="button" id="audioOverlayButton" aria-label="Musik und Visualisierung starten">
     ▶️ Play – Musik & Visualisierung starten
@@ -1636,6 +1717,45 @@ const params = {
   motionNoiseStrength: 1.0,
   motionNoiseScale: 1.0
 };
+
+const INITIAL_SCENE_PRESET = Object.freeze({
+  count: 3600,
+  radius: 180,
+  distribution: 'fibonacci',
+  sizeVar: 3.6,
+  cluster: 0.38,
+  pointAlpha: 0.85,
+  pointHue: 208,
+  pointSaturation: 0.82,
+  pointValue: 1.0,
+  colorMode: 'radialPulse',
+  colorIntensity: 0.9,
+  colorSpeed: 0.65,
+  hueSpread: 68,
+  colorPropagationDistance: 220,
+  colorPropagationDuration: 7.5,
+  colorToneCount: 4,
+  seedStars: 531,
+  catSmallCount: 1900,
+  catMediumCount: 1100,
+  catLargeCount: 600,
+  sizeFactorTiny: 0.22,
+  sizeFactorSmall: 1.1,
+  sizeFactorMedium: 1.55,
+  sizeFactorLarge: 1.9,
+  tinyCount: 1800,
+  connPercent: 0.35,
+  tinyAlpha: 0.45,
+  seedTiny: 987,
+  edgeSoftness: 0.68,
+  blending: 'Additive',
+  filled: false,
+  motionMode: 'sine',
+  motionSpeed: 0.75,
+  motionAmplitude: 14,
+  motionNoiseStrength: 0.5,
+  motionNoiseScale: 1.35
+});
 
 function clampTotalCount(value) {
   const numeric = Math.floor(Number(value) || 0);
@@ -4182,6 +4302,8 @@ const panelLockBtn = $('panelCameraLock');
 const panelRandomBtn = $('panelRandom');
 const sheetHandleBtn = $('sheetHandle');
 const panelHoverZone = $('panelHoverZone');
+const mobileHint = $('mobileHint');
+const mobileHintDismissBtn = $('mobileHintDismiss');
 const mobileSheetQuery = window.matchMedia('(max-width: 768px)');
 const sheetState = {
   mode: 'compact',
@@ -4203,6 +4325,34 @@ const panelGestureState = {
 };
 let hoverCloseTimer = null;
 let hoverPointerInside = false;
+let mobileHintDismissed = false;
+let panelVisible = true;
+
+function setMobileHintVisible(visible) {
+  if (!mobileHint) return;
+  const state = visible ? 'true' : 'false';
+  mobileHint.dataset.visible = state;
+  mobileHint.setAttribute('aria-hidden', visible ? 'false' : 'true');
+}
+
+function dismissMobileHint() {
+  if (mobileHintDismissed) return;
+  mobileHintDismissed = true;
+  setMobileHintVisible(false);
+}
+
+function updateMobileHintVisibility() {
+  if (!mobileHint) return;
+  const shouldShow = !mobileHintDismissed && isMobileSheetActive() && !panelVisible;
+  setMobileHintVisible(shouldShow);
+}
+
+if (mobileHintDismissBtn) {
+  mobileHintDismissBtn.addEventListener('click', () => {
+    dismissMobileHint();
+    updateMobileHintVisibility();
+  });
+}
 
 modelUI.fileInput = $('modelFile');
 modelUI.status = $('modelStatus');
@@ -4591,7 +4741,6 @@ if (audioUI.fileMeta || audioUI.playlistMeta) {
 setAudioStatus('Audio-Reaktivität inaktiv', 'idle');
 refreshAudioUI();
 presetPlaylistPromise = ensurePresetPlaylistInitialized();
-let panelVisible = true;
 let audioPanelVisible = true;
 let cameraLocked = false;
 
@@ -4768,11 +4917,17 @@ function handleMobileMediaChange() {
     setSheetMode('compact', { force: true });
   }
   recalculateSheetMetrics();
+  updateMobileHintVisibility();
 }
 
 function setPanelVisible(show) {
+  const wasVisible = panelVisible;
   panelVisible = !!show;
   panel.classList.toggle('is-hidden', !panelVisible);
+  if (panelVisible && !wasVisible) {
+    dismissMobileHint();
+  }
+
   if (isMobileSheetActive()) {
     if (panelVisible) {
       setSheetMode('compact', { force: true });
@@ -4798,6 +4953,7 @@ function setPanelVisible(show) {
     updateSceneInset(0);
   }
   updateSheetHandleAria();
+  updateMobileHintVisibility();
 }
 
 function setCameraLocked(lock) {
@@ -5894,6 +6050,30 @@ if (panelLockBtn) {
   });
 }
 
+function applyScenePreset(preset, { syncUI = true } = {}) {
+  if (!preset || typeof preset !== 'object') {
+    return false;
+  }
+  let updated = false;
+  for (const [key, value] of Object.entries(preset)) {
+    if (!(key in params)) continue;
+    if (value === undefined) continue;
+    params[key] = value;
+    updated = true;
+  }
+  if (!updated) {
+    return false;
+  }
+  enforceBounds();
+  updatePointColor();
+  rebuildStars();
+  if (syncUI) {
+    setSliders();
+  }
+  applyAudioVisualState();
+  return true;
+}
+
 function randomizeParameters({ syncUI = true } = {}) {
   const totalCount = 500 + Math.floor(Math.random() * 7500);
   params.count = clampTotalCount(totalCount);
@@ -6051,6 +6231,7 @@ window.addEventListener('resize', () => {
   if (isMobileSheetActive()) {
     applySheetOffset();
   }
+  updateMobileHintVisibility();
 });
 
 window.addEventListener('orientationchange', () => {
@@ -6059,6 +6240,7 @@ window.addEventListener('orientationchange', () => {
     if (isMobileSheetActive()) {
       applySheetOffset();
     }
+    updateMobileHintVisibility();
   }, 120);
 });
 
@@ -6127,10 +6309,17 @@ const initialPanelVisible = window.innerWidth > 580;
 setPanelVisible(initialPanelVisible);
 resetCameraView({ immediate: true });
 setCameraLocked(false);
-updatePointColor(false);
+const presetApplied = applyScenePreset(INITIAL_SCENE_PRESET, { syncUI: false });
+if (!presetApplied) {
+  updatePointColor(false);
+  rebuildStars();
+}
 setSliders();
-rebuildStars();
 applyAudioVisualState();
+updateMobileHintVisibility();
+if (document.body) {
+  document.body.classList.remove('is-preparing');
+}
 requestAnimationFrame(animate);
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Hide the control panel while the app initializes on touch devices, restyle the mobile audio controls, and add a dismissible long-press hint overlay for mobile users.
- Load a curated initial scene preset so the visualization is populated on first launch.

## Testing
- No automated tests were run (static HTML/JS project).


------
https://chatgpt.com/codex/tasks/task_e_68e4193f99f08324bbe11f767f2b5a87