### PR TITLE
Enhance mobile control panel interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,42 +15,118 @@
     </button>
   </div>
   <nav class="control-panel-tabs" aria-label="Panel-Navigation">
-    <button type="button" class="control-panel-tab" data-panel-tab="media" aria-controls="audioPanel" aria-pressed="false">
-      🎧 Media Player
+    <button
+      type="button"
+      class="control-panel-tab"
+      data-panel-tab="media"
+      aria-controls="audioPanel"
+      aria-pressed="false"
+      aria-label="Media Player Panel öffnen"
+    >
+      <span class="control-panel-tab__dot" aria-hidden="true"></span>
+      <span class="sr-only">Media Player</span>
     </button>
-    <button type="button" class="control-panel-tab is-active" data-panel-tab="presets" aria-controls="visualPresetsPanel" aria-pressed="true">
-      🎨 Visual Presets
+    <button
+      type="button"
+      class="control-panel-tab is-active"
+      data-panel-tab="presets"
+      aria-controls="visualPresetsPanel"
+      aria-pressed="true"
+      aria-label="Visual-Presets-Panel öffnen"
+    >
+      <span class="control-panel-tab__dot" aria-hidden="true"></span>
+      <span class="sr-only">Visual Presets</span>
     </button>
-    <button type="button" class="control-panel-tab" data-panel-tab="config" aria-controls="configPanel" aria-pressed="false">
-      🛠️ Config
+    <button
+      type="button"
+      class="control-panel-tab"
+      data-panel-tab="config"
+      aria-controls="configPanel"
+      aria-pressed="false"
+      aria-label="Config-Panel öffnen"
+    >
+      <span class="control-panel-tab__dot" aria-hidden="true"></span>
+      <span class="sr-only">Config</span>
     </button>
   </nav>
   <section class="control-panel control-panel--presets" id="visualPresetsPanel" data-panel="presets" aria-labelledby="visualPresetsHeading">
     <header class="control-panel__header">
       <div class="control-panel__title">
-        <h2 id="visualPresetsHeading">Visual Presets</h2>
-        <p class="control-panel__subtitle">Kuratiere Presets, speichere Favoriten und stelle Zufallssets zusammen.</p>
+        <div class="heading-with-info" data-info-size="medium">
+          <h2 id="visualPresetsHeading">Visual Presets</h2>
+          <button
+            type="button"
+            class="info-trigger"
+            data-info-target="infoVisualPresets"
+            aria-label="Hinweis zu Visual Presets anzeigen"
+            aria-expanded="false"
+            aria-controls="infoVisualPresets"
+          >
+            <span aria-hidden="true">?</span>
+          </button>
+          <div class="info-popover" id="infoVisualPresets" role="dialog" hidden>
+            <p class="control-panel__subtitle">Kuratiere Presets, speichere Favoriten und stelle Zufallssets zusammen.</p>
+          </div>
+        </div>
       </div>
       <button type="button" class="control-panel__toggle" data-panel-toggle aria-expanded="true" aria-label="Panel einklappen">⬇️</button>
     </header>
     <div class="control-panel__body">
       <section class="panel-card panel-card--studio" id="patternStudio" aria-labelledby="patternStudioTitle">
         <header class="panel-card__header">
-          <div>
+          <div class="heading-with-info" data-info-size="wide">
             <h3 id="patternStudioTitle">Pattern-Studio</h3>
-            <p class="panel-card__subtitle">Starte mit kuratierten Presets oder forme deine eigene Ordnung aus dem Chaos.</p>
+            <button
+              type="button"
+              class="info-trigger"
+              data-info-target="infoPatternStudio"
+              aria-label="Hinweis zum Pattern-Studio anzeigen"
+              aria-expanded="false"
+              aria-controls="infoPatternStudio"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
+            <div class="info-popover" id="infoPatternStudio" role="dialog" hidden>
+              <p class="panel-card__subtitle">Starte mit kuratierten Presets oder forme deine eigene Ordnung aus dem Chaos.</p>
+            </div>
           </div>
           <button type="button" class="panel-card__action" id="patternFocus" aria-label="Kamera auf Mittelpunkt ausrichten">📌 Fokus</button>
         </header>
         <div class="pattern-quick" id="patternPresetList" role="list" aria-label="Empfohlene Muster"></div>
         <div class="pattern-active">
-          <span class="pattern-active__label" id="patternActiveName">Aktives Muster: Freestyle</span>
-          <p class="pattern-active__description" id="patternActiveDescription">Nutze Presets oder die Regler unten, um dein persönliches Sternenfeld zu gestalten.</p>
+          <div class="pattern-active__header heading-with-info" data-info-size="compact">
+            <span class="pattern-active__label" id="patternActiveName">Aktives Muster: Freestyle</span>
+            <button
+              type="button"
+              class="info-trigger"
+              data-info-target="infoPatternActive"
+              aria-label="Beschreibung zum aktiven Muster anzeigen"
+              aria-expanded="false"
+              aria-controls="infoPatternActive"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
+            <div class="info-popover" id="infoPatternActive" role="dialog" hidden>
+              <p class="pattern-active__description" id="patternActiveDescription">Nutze Presets oder die Regler unten, um dein persönliches Sternenfeld zu gestalten.</p>
+            </div>
+          </div>
         </div>
         <div class="pattern-formations">
-          <div class="pattern-formations__head">
+          <div class="pattern-formations__head heading-with-info" data-info-size="compact" data-info-align="start">
             <h4 id="patternFormationTitle">Formationen</h4>
-            <p class="pattern-formations__hint">Wechsle schnell zwischen geometrischen Anordnungen. STL-Importe erscheinen hier automatisch.</p>
+            <button
+              type="button"
+              class="info-trigger"
+              data-info-target="infoPatternFormations"
+              aria-label="Hinweis zu Formationen anzeigen"
+              aria-expanded="false"
+              aria-controls="infoPatternFormations"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
+            <div class="info-popover" id="infoPatternFormations" role="dialog" hidden>
+              <p class="pattern-formations__hint">Wechsle schnell zwischen geometrischen Anordnungen. STL-Importe erscheinen hier automatisch.</p>
+            </div>
           </div>
           <div class="chip-group" id="patternDistributionChips" role="group" aria-labelledby="patternFormationTitle"></div>
         </div>
@@ -61,9 +137,22 @@
       </section>
       <section class="panel-card panel-card--studio" id="presetStudio" aria-labelledby="presetStudioTitle">
         <header class="panel-card__header">
-          <div>
+          <div class="heading-with-info" data-info-size="wide">
             <h3 id="presetStudioTitle">Preset-Studio</h3>
-            <p class="panel-card__subtitle">Kopiere deine aktuelle Szene, kehre zum Ausgangspunkt zurück oder starte einen Mix.</p>
+            <button
+              type="button"
+              class="info-trigger"
+              data-info-target="infoPresetStudio"
+              aria-label="Hinweis zum Preset-Studio anzeigen"
+              aria-expanded="false"
+              aria-controls="infoPresetStudio"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
+            <div class="info-popover" id="infoPresetStudio" role="dialog" hidden>
+              <p class="panel-card__subtitle">Kopiere deine aktuelle Szene, kehre zum Ausgangspunkt zurück oder starte einen Mix.</p>
+              <p class="preset-studio__note">Nutze das Config-Panel, um eigene Presets zu speichern und sie anschließend hier oder in der Galerie auszuwählen.</p>
+            </div>
           </div>
         </header>
         <div class="preset-studio__actions">
@@ -74,13 +163,24 @@
         <div class="preset-studio__status" id="presetStudioStatus" data-state="info" role="status" aria-live="polite">
           Tipp: Kopiere dein aktuelles Preset, um es zu teilen oder später erneut zu laden.
         </div>
-        <p class="preset-studio__note">Nutze das Config-Panel, um eigene Presets zu speichern und sie anschließend hier oder in der Galerie auszuwählen.</p>
       </section>
       <section class="panel-card panel-card--presets" aria-labelledby="userPresetTitle">
         <header class="panel-card__header">
-          <div>
+          <div class="heading-with-info" data-info-size="wide">
             <h3 id="userPresetTitle">Gespeicherte Presets</h3>
-            <p class="panel-card__subtitle">Wähle mehrere Presets für die Galerie oder starte die zufällige Wiedergabe.</p>
+            <button
+              type="button"
+              class="info-trigger"
+              data-info-target="infoUserPresets"
+              aria-label="Hinweis zu gespeicherten Presets anzeigen"
+              aria-expanded="false"
+              aria-controls="infoUserPresets"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
+            <div class="info-popover" id="infoUserPresets" role="dialog" hidden>
+              <p class="panel-card__subtitle">Wähle mehrere Presets für die Galerie oder starte die zufällige Wiedergabe.</p>
+            </div>
           </div>
           <div class="panel-card__action-group">
             <button type="button" class="panel-card__action" id="presetGalleryToggle" aria-pressed="false">🖼️ Galerie</button>

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -4399,6 +4399,8 @@ export function bootstrapApp() {
     moved: false,
     preventClick: false,
   };
+  const SHEET_EXTRA_DRAG_PX = 140;
+  const SHEET_HIDE_TRIGGER_PX = 90;
   const doubleTapState = { lastTime: 0, lastX: 0, lastY: 0, blockUntil: 0 };
   const DOUBLE_TAP_TIMEOUT_MS = 420;
   const DOUBLE_TAP_DISTANCE_PX = 46;
@@ -4437,6 +4439,9 @@ export function bootstrapApp() {
   const controlPanelRegistry = new Map();
   const controlPanelTabs = new Map();
   const desktopPanelState = new Map();
+  const PANEL_ORDER = ['media', 'presets', 'config'];
+  const infoPopoverState = { trigger: null, popover: null, hideTimeoutId: null };
+  let infoDocumentListenersReady = false;
   let mobileActivePanel = 'presets';
   let lastExpandedPanel = 'presets';
 
@@ -4468,6 +4473,187 @@ export function bootstrapApp() {
 
   updateViewportMetrics();
 
+  function closeActiveInfoPopover() {
+    if (!infoPopoverState.trigger || !infoPopoverState.popover) {
+      return;
+    }
+    const { trigger, popover } = infoPopoverState;
+    if (infoPopoverState.hideTimeoutId !== null) {
+      clearTimeout(infoPopoverState.hideTimeoutId);
+      infoPopoverState.hideTimeoutId = null;
+    }
+    trigger.setAttribute('aria-expanded', 'false');
+    popover.classList.remove('is-visible');
+    popover.setAttribute('aria-hidden', 'true');
+    const timeoutId = window.setTimeout(() => {
+      if (!popover.classList.contains('is-visible')) {
+        popover.hidden = true;
+      }
+      if (infoPopoverState.hideTimeoutId === timeoutId) {
+        infoPopoverState.hideTimeoutId = null;
+      }
+    }, 220);
+    infoPopoverState.trigger = null;
+    infoPopoverState.popover = null;
+    infoPopoverState.hideTimeoutId = timeoutId;
+  }
+
+  function openInfoPopover(trigger, popover) {
+    if (!trigger || !popover) {
+      return;
+    }
+    if (infoPopoverState.trigger === trigger) {
+      closeActiveInfoPopover();
+      return;
+    }
+    closeActiveInfoPopover();
+    if (infoPopoverState.hideTimeoutId !== null) {
+      clearTimeout(infoPopoverState.hideTimeoutId);
+      infoPopoverState.hideTimeoutId = null;
+    }
+    popover.hidden = false;
+    popover.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => {
+      popover.classList.add('is-visible');
+    });
+    trigger.setAttribute('aria-expanded', 'true');
+    infoPopoverState.trigger = trigger;
+    infoPopoverState.popover = popover;
+  }
+
+  function ensureInfoDocumentListeners() {
+    if (infoDocumentListenersReady) {
+      return;
+    }
+    infoDocumentListenersReady = true;
+    document.addEventListener('click', event => {
+      if (!infoPopoverState.trigger || !infoPopoverState.popover) {
+        return;
+      }
+      const target = event.target;
+      if (!target) return;
+      if (infoPopoverState.popover.contains(target)) return;
+      if (infoPopoverState.trigger.contains(target)) return;
+      closeActiveInfoPopover();
+    });
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && infoPopoverState.trigger) {
+        closeActiveInfoPopover();
+      }
+    });
+  }
+
+  function setupInfoPopovers() {
+    ensureInfoDocumentListeners();
+    document.querySelectorAll('[data-info-target]').forEach(trigger => {
+      if (!trigger || trigger.dataset.infoInitialized === 'true') {
+        return;
+      }
+      const targetId = trigger.dataset.infoTarget;
+      if (!targetId) return;
+      const popover = document.getElementById(targetId);
+      if (!popover) return;
+      trigger.dataset.infoInitialized = 'true';
+      trigger.setAttribute('aria-expanded', 'false');
+      popover.hidden = true;
+      popover.setAttribute('aria-hidden', 'true');
+      trigger.addEventListener('click', event => {
+        event.preventDefault();
+        openInfoPopover(trigger, popover);
+      });
+    });
+  }
+
+  const panelSwipeState = {
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    startTime: 0,
+    active: false,
+  };
+
+  function resetPanelSwipeState() {
+    panelSwipeState.pointerId = null;
+    panelSwipeState.startX = 0;
+    panelSwipeState.startY = 0;
+    panelSwipeState.startTime = 0;
+    panelSwipeState.active = false;
+  }
+
+  function movePanelBySwipe(direction) {
+    if (!isMobileSheetActive()) return false;
+    const order = PANEL_ORDER.filter(key => controlPanelRegistry.has(key));
+    if (order.length === 0) return false;
+    const currentKey = order.includes(mobileActivePanel) ? mobileActivePanel : order[0];
+    const currentIndex = order.indexOf(currentKey);
+    const nextIndex = currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= order.length) {
+      return false;
+    }
+    const nextKey = order[nextIndex];
+    expandControlPanel(nextKey, { fromTab: true });
+    return true;
+  }
+
+  function startPanelSwipe(event) {
+    if (!isMobileSheetActive() || !panelVisible) return;
+    if (!event || !event.isPrimary) return;
+    if (sheetState.pointerId !== null) return;
+    const pointerType = event.pointerType || '';
+    if (pointerType === 'mouse') return;
+    const target = event.target;
+    if (target) {
+      if (target.closest('.sheet-handle')) return;
+      if (target.closest('button, input, select, textarea, a, [data-no-swipe]')) return;
+    }
+    panelSwipeState.pointerId = event.pointerId;
+    panelSwipeState.startX = Number.isFinite(event.clientX) ? event.clientX : 0;
+    panelSwipeState.startY = Number.isFinite(event.clientY) ? event.clientY : 0;
+    panelSwipeState.startTime = performance.now();
+    panelSwipeState.active = true;
+  }
+
+  function handlePanelSwipeMove(event) {
+    if (!panelSwipeState.active || !event || event.pointerId !== panelSwipeState.pointerId) {
+      return;
+    }
+    const dx = Number.isFinite(event.clientX) ? event.clientX - panelSwipeState.startX : 0;
+    const dy = Number.isFinite(event.clientY) ? event.clientY - panelSwipeState.startY : 0;
+    if (Math.abs(dy) > Math.abs(dx) * 1.4) {
+      resetPanelSwipeState();
+    }
+  }
+
+  function finishPanelSwipe(event) {
+    if (!panelSwipeState.active || !event || event.pointerId !== panelSwipeState.pointerId) {
+      return;
+    }
+    const dx = Number.isFinite(event.clientX) ? event.clientX - panelSwipeState.startX : 0;
+    const dy = Number.isFinite(event.clientY) ? event.clientY - panelSwipeState.startY : 0;
+    const elapsed = performance.now() - panelSwipeState.startTime;
+    resetPanelSwipeState();
+    if (Math.abs(dy) > Math.abs(dx) * 1.2) {
+      return;
+    }
+    const absX = Math.abs(dx);
+    const quickSwipe = absX > 28 && elapsed < 220;
+    if (!quickSwipe && absX < 50) {
+      return;
+    }
+    const direction = dx < 0 ? 1 : -1;
+    movePanelBySwipe(direction);
+  }
+
+  function cancelPanelSwipe(event) {
+    if (!panelSwipeState.active) {
+      return;
+    }
+    if (event && panelSwipeState.pointerId !== null && event.pointerId !== panelSwipeState.pointerId) {
+      return;
+    }
+    resetPanelSwipeState();
+  }
+
   document.querySelectorAll('.control-panel[data-panel]').forEach(panelEl => {
     const key = panelEl.dataset.panel;
     if (!key) return;
@@ -4478,6 +4664,11 @@ export function bootstrapApp() {
     updatePanelToggleLabel(controlPanelRegistry.get(key), expanded);
     if (expanded) {
       lastExpandedPanel = key;
+    }
+    if (mobileSheetQuery.matches && !expanded) {
+      panelEl.hidden = true;
+    } else {
+      panelEl.hidden = false;
     }
     if (toggle) {
       toggle.addEventListener('click', () => {
@@ -4540,6 +4731,14 @@ export function bootstrapApp() {
     if (entry.toggle) {
       entry.toggle.setAttribute('aria-expanded', 'false');
     }
+    if (mobileSheetQuery.matches) {
+      entry.el.hidden = true;
+    } else {
+      entry.el.hidden = false;
+    }
+    if (infoPopoverState.popover && entry.el.contains(infoPopoverState.popover)) {
+      closeActiveInfoPopover();
+    }
     updatePanelToggleLabel(entry, false);
     if (!preserveDesktop && !mobileSheetQuery.matches) {
       desktopPanelState.set(key, false);
@@ -4558,6 +4757,7 @@ export function bootstrapApp() {
   }
 
   function expandControlPanel(key, { fromTab = false, preserveDesktop = false } = {}) {
+    closeActiveInfoPopover();
     const entry = controlPanelRegistry.get(key);
     if (!entry) return;
     if (entry.expanded && !mobileSheetQuery.matches) {
@@ -4570,6 +4770,7 @@ export function bootstrapApp() {
     entry.expanded = true;
     entry.el.classList.remove('is-collapsed');
     entry.el.setAttribute('aria-hidden', 'false');
+    entry.el.hidden = false;
     if (entry.toggle) {
       entry.toggle.setAttribute('aria-expanded', 'true');
     }
@@ -4619,9 +4820,12 @@ export function bootstrapApp() {
       mobileActivePanel = 'presets';
     }
     initializeControlPanels();
+    setupInfoPopovers();
+    closeActiveInfoPopover();
   });
 
   initializeControlPanels();
+  setupInfoPopovers();
 
   audioUI.panel = $('audioPanel');
   audioUI.body = $('audioPanelBody');
@@ -5262,6 +5466,8 @@ export function bootstrapApp() {
       setAudioPanelVisible(panelVisible);
       return;
     }
+    closeActiveInfoPopover();
+    cancelPanelSwipe();
     panel.classList.toggle('is-hidden', !panelVisible);
     panel.setAttribute('aria-hidden', panelVisible ? 'false' : 'true');
     if (isMobileSheetActive()) {
@@ -5274,6 +5480,8 @@ export function bootstrapApp() {
     }
     setAudioPanelVisible(panelVisible);
     if (!panelVisible) {
+      sheetState.mode = 'compact';
+      panel.removeAttribute('data-sheet-state');
       if (sheetState.pointerId !== null && panel.releasePointerCapture) {
         try { panel.releasePointerCapture(sheetState.pointerId); } catch (err) { /* noop */ }
       }
@@ -5281,6 +5489,8 @@ export function bootstrapApp() {
       sheetState.moved = false;
       sheetState.preventClick = false;
       panel.classList.remove('is-dragging');
+      sheetState.lastOffset = getSheetCompactOffset();
+      applySheetOffset();
     }
     updateSheetHandleAria();
   }
@@ -5432,7 +5642,12 @@ export function bootstrapApp() {
     const maxOffset = getSheetCompactOffset();
     let next = sheetState.startOffset + delta;
     if (!Number.isFinite(next)) next = 0;
-    next = Math.max(0, Math.min(maxOffset, next));
+    const hideLimit = maxOffset + SHEET_EXTRA_DRAG_PX;
+    if (next > maxOffset) {
+      const overshoot = Math.min(hideLimit - maxOffset, next - maxOffset);
+      next = maxOffset + overshoot * 0.6;
+    }
+    next = Math.max(0, Math.min(hideLimit, next));
     if (Math.abs(delta) > 6) {
       sheetState.moved = true;
     }
@@ -5451,6 +5666,12 @@ export function bootstrapApp() {
     sheetState.pointerId = null;
     sheetState.moved = false;
     const maxOffset = getSheetCompactOffset();
+    const hideThreshold = maxOffset + SHEET_HIDE_TRIGGER_PX;
+    if (lastOffset >= hideThreshold) {
+      setPanelVisible(false);
+      sheetState.preventClick = true;
+      return;
+    }
     if (moved) {
       const threshold = maxOffset * 0.45;
       const nextState = lastOffset > threshold ? 'compact' : 'expanded';
@@ -5784,6 +6005,10 @@ export function bootstrapApp() {
   }
 
   async function triggerDoubleTapAction() {
+    if (!panelVisible && isMobileSheetActive()) {
+      setPanelVisible(true);
+      return;
+    }
     randomizeParameters({ syncUI: true });
     try {
       const started = await requestPlaybackStart({ preferCurrent: false });
@@ -6521,6 +6746,11 @@ export function bootstrapApp() {
   panel.addEventListener('pointermove', handleSheetDragMove);
   panel.addEventListener('pointerup', finishSheetDrag);
   panel.addEventListener('pointercancel', finishSheetDrag);
+
+  panel.addEventListener('pointerdown', startPanelSwipe);
+  panel.addEventListener('pointermove', handlePanelSwipeMove);
+  panel.addEventListener('pointerup', finishPanelSwipe);
+  panel.addEventListener('pointercancel', cancelPanelSwipe);
 
   if (mobileSheetQuery.addEventListener) {
     mobileSheetQuery.addEventListener('change', handleMobileMediaChange);

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,6 +62,18 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (min-width: 64rem) {
   body {
     font-size: var(--font-size-desktop);
@@ -221,9 +233,10 @@ body {
 }
 
 .control-panel-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--spacing-s);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
   margin: 0;
   padding: 0;
   position: sticky;
@@ -241,36 +254,48 @@ body {
 
 .control-panel-tab {
   appearance: none;
-  border: 1px solid var(--color-border);
+  background: transparent;
+  border: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  color: inherit;
-  font-size: 0.85rem;
-  letter-spacing: 0.01em;
-  cursor: pointer;
+  width: 0.75rem;
+  height: 0.75rem;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
-  padding: 0.5rem 0.6rem;
+  cursor: pointer;
+  transition: transform 0.25s ease;
+  touch-action: manipulation;
+}
+
+.control-panel-tab__dot {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22);
   transition:
-    border-color 0.2s ease,
-    background 0.2s ease,
-    transform 0.2s ease;
+    transform 0.25s ease,
+    background 0.25s ease,
+    box-shadow 0.25s ease;
 }
 
-.control-panel-tab.is-active,
-.control-panel-tab[aria-pressed='true'] {
-  border-color: var(--color-primary);
-  background: rgba(79, 140, 255, 0.22);
-  transform: translateY(-1px);
+.control-panel-tab.is-active .control-panel-tab__dot,
+.control-panel-tab[aria-pressed='true'] .control-panel-tab__dot {
+  background: rgba(79, 140, 255, 0.95);
+  box-shadow: 0 0 0 4px rgba(79, 140, 255, 0.18);
+  transform: scale(1.3);
 }
 
-.control-panel-tab:hover,
+.control-panel-tab:hover .control-panel-tab__dot,
+.control-panel-tab:focus-visible .control-panel-tab__dot {
+  background: rgba(79, 140, 255, 0.7);
+  box-shadow: 0 0 0 4px rgba(79, 140, 255, 0.24);
+}
+
 .control-panel-tab:focus-visible {
-  border-color: var(--color-primary);
-  background: rgba(79, 140, 255, 0.3);
   outline: none;
+  transform: translateY(-1px);
 }
 
 .control-panel {
@@ -297,6 +322,112 @@ body {
   margin: 0;
   font-size: 1rem;
   letter-spacing: 0.01em;
+}
+
+.heading-with-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  position: relative;
+  flex-wrap: nowrap;
+}
+
+.heading-with-info[data-info-align='start'] {
+  justify-content: flex-start;
+}
+
+.heading-with-info > h2,
+.heading-with-info > h3,
+.heading-with-info > h4,
+.heading-with-info > span {
+  margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.control-panel__title .heading-with-info,
+.panel-card__header .heading-with-info {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.info-trigger {
+  width: 1.35rem;
+  height: 1.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.4rem;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-secondary);
+  font-size: 0.82rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.info-trigger:hover,
+.info-trigger:focus-visible {
+  border-color: var(--color-primary);
+  background: rgba(79, 140, 255, 0.2);
+  color: var(--color-text-primary);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.info-popover {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 12rem;
+  max-width: min(22rem, calc(100vw - 3rem));
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--radius-s);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(6, 10, 18, 0.96);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+  color: var(--color-text-secondary);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-6px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+  z-index: 20;
+}
+
+.info-popover p {
+  margin: 0;
+}
+
+.info-popover p + p {
+  margin-top: 0.6rem;
+}
+
+.info-popover.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.heading-with-info[data-info-align='end'] .info-popover {
+  left: auto;
+  right: 0;
+}
+
+.heading-with-info[data-info-size='compact'] .info-popover {
+  max-width: min(16rem, calc(100vw - 3rem));
+}
+
+.heading-with-info[data-info-size='medium'] .info-popover {
+  max-width: min(18rem, calc(100vw - 3rem));
 }
 
 .control-panel__subtitle {


### PR DESCRIPTION
## Summary
- replace the text tabs with dot indicators and add contextual help popovers throughout the presets panel
- update the mobile styles for the navigation dots and info triggers to match the reduced layout
- add popover helpers, swipe navigation, and improved sheet closing/double-tap reopening logic in the app code

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e54a6d6c408324bc0adac0179ee056