### PR TITLE
feat: streamline panel UI navigation and contextual help

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,21 +15,55 @@
     </button>
   </div>
   <nav class="control-panel-tabs" aria-label="Panel-Navigation">
-    <button type="button" class="control-panel-tab" data-panel-tab="media" aria-controls="audioPanel" aria-pressed="false">
-      🎧 Media Player
+    <button
+      type="button"
+      class="control-panel-tab"
+      data-panel-tab="media"
+      aria-controls="audioPanel"
+      aria-pressed="false"
+      aria-label="Media Player"
+    >
+      <span class="control-panel-tab__dot" aria-hidden="true"></span>
+      <span class="sr-only">Media Player</span>
     </button>
-    <button type="button" class="control-panel-tab is-active" data-panel-tab="presets" aria-controls="visualPresetsPanel" aria-pressed="true">
-      🎨 Visual Presets
+    <button
+      type="button"
+      class="control-panel-tab is-active"
+      data-panel-tab="presets"
+      aria-controls="visualPresetsPanel"
+      aria-pressed="true"
+      aria-label="Visual Presets"
+    >
+      <span class="control-panel-tab__dot" aria-hidden="true"></span>
+      <span class="sr-only">Visual Presets</span>
     </button>
-    <button type="button" class="control-panel-tab" data-panel-tab="config" aria-controls="configPanel" aria-pressed="false">
-      🛠️ Config
+    <button
+      type="button"
+      class="control-panel-tab"
+      data-panel-tab="config"
+      aria-controls="configPanel"
+      aria-pressed="false"
+      aria-label="Config"
+    >
+      <span class="control-panel-tab__dot" aria-hidden="true"></span>
+      <span class="sr-only">Config</span>
     </button>
   </nav>
   <section class="control-panel control-panel--presets" id="visualPresetsPanel" data-panel="presets" aria-labelledby="visualPresetsHeading">
     <header class="control-panel__header">
       <div class="control-panel__title">
         <h2 id="visualPresetsHeading">Visual Presets</h2>
-        <p class="control-panel__subtitle">Kuratiere Presets, speichere Favoriten und stelle Zufallssets zusammen.</p>
+        <p class="control-panel__subtitle info-source" id="visualPresetsInfo">Kuratiere Presets, speichere Favoriten und stelle Zufallssets zusammen.</p>
+        <button
+          type="button"
+          class="info-badge"
+          data-info-popup
+          data-info-target="visualPresetsInfo"
+          aria-label="Hinweis zu Visual Presets"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">?</span>
+        </button>
       </div>
       <button type="button" class="control-panel__toggle" data-panel-toggle aria-expanded="true" aria-label="Panel einklappen">⬇️</button>
     </header>
@@ -38,19 +72,49 @@
         <header class="panel-card__header">
           <div>
             <h3 id="patternStudioTitle">Pattern-Studio</h3>
-            <p class="panel-card__subtitle">Starte mit kuratierten Presets oder forme deine eigene Ordnung aus dem Chaos.</p>
+            <p class="panel-card__subtitle info-source" id="patternStudioInfo">Starte mit kuratierten Presets oder forme deine eigene Ordnung aus dem Chaos.</p>
+            <button
+              type="button"
+              class="info-badge"
+              data-info-popup
+              data-info-target="patternStudioInfo"
+              aria-label="Hinweis zum Pattern-Studio"
+              aria-expanded="false"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
           </div>
           <button type="button" class="panel-card__action" id="patternFocus" aria-label="Kamera auf Mittelpunkt ausrichten">📌 Fokus</button>
         </header>
         <div class="pattern-quick" id="patternPresetList" role="list" aria-label="Empfohlene Muster"></div>
         <div class="pattern-active">
           <span class="pattern-active__label" id="patternActiveName">Aktives Muster: Freestyle</span>
-          <p class="pattern-active__description" id="patternActiveDescription">Nutze Presets oder die Regler unten, um dein persönliches Sternenfeld zu gestalten.</p>
+          <p class="pattern-active__description info-source" id="patternActiveDescription">Nutze Presets oder die Regler unten, um dein persönliches Sternenfeld zu gestalten.</p>
+          <button
+            type="button"
+            class="info-badge info-badge--inline"
+            data-info-popup
+            data-info-target="patternActiveDescription"
+            aria-label="Hinweis zum aktiven Muster"
+            aria-expanded="false"
+          >
+            <span aria-hidden="true">?</span>
+          </button>
         </div>
         <div class="pattern-formations">
           <div class="pattern-formations__head">
             <h4 id="patternFormationTitle">Formationen</h4>
-            <p class="pattern-formations__hint">Wechsle schnell zwischen geometrischen Anordnungen. STL-Importe erscheinen hier automatisch.</p>
+            <p class="pattern-formations__hint info-source" id="patternFormationHint">Wechsle schnell zwischen geometrischen Anordnungen. STL-Importe erscheinen hier automatisch.</p>
+            <button
+              type="button"
+              class="info-badge info-badge--inline"
+              data-info-popup
+              data-info-target="patternFormationHint"
+              aria-label="Hinweis zu Formationen"
+              aria-expanded="false"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
           </div>
           <div class="chip-group" id="patternDistributionChips" role="group" aria-labelledby="patternFormationTitle"></div>
         </div>
@@ -63,7 +127,17 @@
         <header class="panel-card__header">
           <div>
             <h3 id="presetStudioTitle">Preset-Studio</h3>
-            <p class="panel-card__subtitle">Kopiere deine aktuelle Szene, kehre zum Ausgangspunkt zurück oder starte einen Mix.</p>
+            <p class="panel-card__subtitle info-source" id="presetStudioInfo">Kopiere deine aktuelle Szene, kehre zum Ausgangspunkt zurück oder starte einen Mix.</p>
+            <button
+              type="button"
+              class="info-badge"
+              data-info-popup
+              data-info-target="presetStudioInfo"
+              aria-label="Hinweis zum Preset-Studio"
+              aria-expanded="false"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
           </div>
         </header>
         <div class="preset-studio__actions">
@@ -74,13 +148,33 @@
         <div class="preset-studio__status" id="presetStudioStatus" data-state="info" role="status" aria-live="polite">
           Tipp: Kopiere dein aktuelles Preset, um es zu teilen oder später erneut zu laden.
         </div>
-        <p class="preset-studio__note">Nutze das Config-Panel, um eigene Presets zu speichern und sie anschließend hier oder in der Galerie auszuwählen.</p>
+        <p class="preset-studio__note info-source" id="presetStudioNote">Nutze das Config-Panel, um eigene Presets zu speichern und sie anschließend hier oder in der Galerie auszuwählen.</p>
+        <button
+          type="button"
+          class="info-badge info-badge--block"
+          data-info-popup
+          data-info-target="presetStudioNote"
+          aria-label="Hinweis zur Nutzung eigener Presets"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">?</span>
+        </button>
       </section>
       <section class="panel-card panel-card--presets" aria-labelledby="userPresetTitle">
         <header class="panel-card__header">
           <div>
             <h3 id="userPresetTitle">Gespeicherte Presets</h3>
-            <p class="panel-card__subtitle">Wähle mehrere Presets für die Galerie oder starte die zufällige Wiedergabe.</p>
+            <p class="panel-card__subtitle info-source" id="userPresetInfo">Wähle mehrere Presets für die Galerie oder starte die zufällige Wiedergabe.</p>
+            <button
+              type="button"
+              class="info-badge"
+              data-info-popup
+              data-info-target="userPresetInfo"
+              aria-label="Hinweis zu gespeicherten Presets"
+              aria-expanded="false"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
           </div>
           <div class="panel-card__action-group">
             <button type="button" class="panel-card__action" id="presetGalleryToggle" aria-pressed="false">🖼️ Galerie</button>
@@ -88,7 +182,17 @@
           </div>
         </header>
         <div class="preset-gallery" id="userPresetGallery" role="list" aria-label="Eigene Presets"></div>
-        <p class="preset-gallery__empty" id="userPresetEmpty">Noch keine Presets gespeichert. Erstelle im Config-Panel deine ersten Favoriten.</p>
+        <p class="preset-gallery__empty info-source" id="userPresetEmpty">Noch keine Presets gespeichert. Erstelle im Config-Panel deine ersten Favoriten.</p>
+        <button
+          type="button"
+          class="info-badge info-badge--block"
+          data-info-popup
+          data-info-target="userPresetEmpty"
+          aria-label="Hinweis zu fehlenden Presets"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">?</span>
+        </button>
       </section>
     </div>
   </section>
@@ -96,7 +200,17 @@
     <header class="control-panel__header">
       <div class="control-panel__title">
         <h2 id="configPanelHeading">Config</h2>
-        <p class="control-panel__subtitle">Speichere deine Einstellungen als Preset oder passe jeden Parameter fein an.</p>
+        <p class="control-panel__subtitle info-source" id="configPanelInfo">Speichere deine Einstellungen als Preset oder passe jeden Parameter fein an.</p>
+        <button
+          type="button"
+          class="info-badge"
+          data-info-popup
+          data-info-target="configPanelInfo"
+          aria-label="Hinweis zum Config-Panel"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">?</span>
+        </button>
       </div>
       <button type="button" class="control-panel__toggle" data-panel-toggle aria-expanded="false" aria-label="Panel einblenden">⬆️</button>
     </header>
@@ -105,7 +219,17 @@
         <header class="panel-card__header">
           <div>
             <h3 id="presetCreateTitle">Visuelles Preset speichern</h3>
-            <p class="panel-card__subtitle">Nutze den aktuellen Stand als neues Preset inklusive Vorschaubild.</p>
+            <p class="panel-card__subtitle info-source" id="presetCreateInfo">Nutze den aktuellen Stand als neues Preset inklusive Vorschaubild.</p>
+            <button
+              type="button"
+              class="info-badge"
+              data-info-popup
+              data-info-target="presetCreateInfo"
+              aria-label="Hinweis zum Speichern eines Presets"
+              aria-expanded="false"
+            >
+              <span aria-hidden="true">?</span>
+            </button>
           </div>
         </header>
         <form class="preset-form" id="presetCreateForm">
@@ -121,7 +245,17 @@
             <button type="submit" id="presetSaveButton">💾 Preset speichern</button>
           </div>
         </form>
-        <p class="preset-form__hint" id="presetFormHint">Deine Presets werden lokal gespeichert und stehen in der Galerie bereit.</p>
+        <p class="preset-form__hint info-source" id="presetFormHint">Deine Presets werden lokal gespeichert und stehen in der Galerie bereit.</p>
+        <button
+          type="button"
+          class="info-badge info-badge--block"
+          data-info-popup
+          data-info-target="presetFormHint"
+          aria-label="Hinweis zur Preset-Speicherung"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">?</span>
+        </button>
       </section>
       <h3>Parameter</h3>
   <section class="accordion" id="acc-points">
@@ -583,7 +717,17 @@
     <header class="control-panel__header">
       <div class="control-panel__title">
         <h2 id="mediaPanelHeading">Media Player</h2>
-        <p class="control-panel__subtitle">Steuere Wiedergabe, Mikrofon und Audio-Reaktivität.</p>
+        <p class="control-panel__subtitle info-source" id="mediaPanelInfo">Steuere Wiedergabe, Mikrofon und Audio-Reaktivität.</p>
+        <button
+          type="button"
+          class="info-badge"
+          data-info-popup
+          data-info-target="mediaPanelInfo"
+          aria-label="Hinweis zum Media Player"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">?</span>
+        </button>
       </div>
       <button type="button" class="control-panel__toggle" data-panel-toggle aria-expanded="false">Panel einblenden</button>
     </header>
@@ -593,7 +737,17 @@
         <div class="audio-player-head__meta">
           <span class="audio-player-head__label">Jetzt läuft</span>
           <h4 class="audio-player-head__title" id="audioCurrentTitle">Keine Auswahl</h4>
-          <p class="audio-player-head__description" id="audioCurrentDetails">Lade eigene Songs oder nutze die Preset-Playlist.</p>
+          <p class="audio-player-head__description info-source" id="audioCurrentDetails">Lade eigene Songs oder nutze die Preset-Playlist.</p>
+          <button
+            type="button"
+            class="info-badge info-badge--inline"
+            data-info-popup
+            data-info-target="audioCurrentDetails"
+            aria-label="Hinweis zur Playlist"
+            aria-expanded="false"
+          >
+            <span aria-hidden="true">?</span>
+          </button>
         </div>
         <div class="audio-player-head__status" role="status" aria-live="polite">
           <span class="status-indicator" id="audioStatusDot" data-state="idle" aria-hidden="true"></span>
@@ -618,14 +772,24 @@
           <div class="file-meta" id="audioFileMeta">Keine Auswahl</div>
         </div>
       </div>
-      <div class="audio-playlist" aria-live="polite">
+        <div class="audio-playlist" aria-live="polite">
         <div class="audio-playlist__head">
           <h4 id="audioPlaylistTitle">Playlist</h4>
           <div class="playlist-meta" id="audioPlaylistMeta">Keine Playlist geladen</div>
         </div>
-        <div class="audio-playlist__list" id="audioPlaylist" role="listbox" aria-label="Wiedergabeliste"></div>
-        <p class="audio-playlist__empty" id="audioPlaylistEmpty">Keine Titel vorhanden. Lade deine Lieblingstracks oder nutze die Presets.</p>
-      </div>
+          <div class="audio-playlist__list" id="audioPlaylist" role="listbox" aria-label="Wiedergabeliste"></div>
+          <p class="audio-playlist__empty info-source" id="audioPlaylistEmpty">Keine Titel vorhanden. Lade deine Lieblingstracks oder nutze die Presets.</p>
+          <button
+            type="button"
+            class="info-badge info-badge--block"
+            data-info-popup
+            data-info-target="audioPlaylistEmpty"
+            aria-label="Hinweis zur leeren Playlist"
+            aria-expanded="false"
+          >
+            <span aria-hidden="true">?</span>
+          </button>
+        </div>
     </section>
     <section class="audio-section audio-section--reactivity">
       <div class="row">

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -4402,6 +4402,9 @@ export function bootstrapApp() {
   const doubleTapState = { lastTime: 0, lastX: 0, lastY: 0, blockUntil: 0 };
   const DOUBLE_TAP_TIMEOUT_MS = 420;
   const DOUBLE_TAP_DISTANCE_PX = 46;
+  const panelSwipeState = { pointerId: null, startX: 0, startY: 0, active: false };
+  const PANEL_SWIPE_MIN_DISTANCE_PX = 60;
+  const PANEL_SWIPE_VERTICAL_TOLERANCE_PX = 42;
   const longPressState = { timerId: null, pointerId: null, startX: 0, startY: 0, triggered: false };
   const LONG_PRESS_DURATION_MS = 600;
   const LONG_PRESS_DISTANCE_PX = 28;
@@ -4437,6 +4440,8 @@ export function bootstrapApp() {
   const controlPanelRegistry = new Map();
   const controlPanelTabs = new Map();
   const desktopPanelState = new Map();
+  const mobilePanelOrder = ['media', 'presets', 'config'];
+  const infoPopoverState = { el: null, trigger: null };
   let mobileActivePanel = 'presets';
   let lastExpandedPanel = 'presets';
 
@@ -4498,14 +4503,17 @@ export function bootstrapApp() {
     controlPanelTabs.set(key, tab);
     tab.addEventListener('click', () => {
       if (mobileSheetQuery.matches) {
+        closeInfoPopover();
         expandControlPanel(key, { fromTab: true });
         return;
       }
       const entry = controlPanelRegistry.get(key);
       if (!entry) return;
       if (entry.expanded && lastExpandedPanel === key) {
+        closeInfoPopover();
         collapseControlPanel(key);
       } else {
+        closeInfoPopover();
         expandControlPanel(key, { fromTab: true });
       }
     });
@@ -4622,6 +4630,140 @@ export function bootstrapApp() {
   });
 
   initializeControlPanels();
+
+  function ensureInfoPopoverElement() {
+    if (infoPopoverState.el) {
+      return infoPopoverState.el;
+    }
+    const popover = document.createElement('div');
+    popover.className = 'info-popover';
+    popover.id = 'infoPopover';
+    popover.setAttribute('role', 'tooltip');
+    popover.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(popover);
+    infoPopoverState.el = popover;
+    return popover;
+  }
+
+  function getInfoContentFromTrigger(trigger) {
+    if (!trigger) return '';
+    const targetId = trigger.dataset.infoTarget;
+    if (targetId) {
+      const target = document.getElementById(targetId);
+      if (target) {
+        return String(target.textContent || '').trim();
+      }
+    }
+    const inline = trigger.dataset.infoContent;
+    if (inline) {
+      return String(inline).trim();
+    }
+    return '';
+  }
+
+  function positionInfoPopover(popover, trigger) {
+    if (!popover || !trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const popRect = popover.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    let top = rect.top - 12;
+    let placement = 'top';
+    if (top - popRect.height < 16) {
+      top = rect.bottom + 12;
+      placement = 'bottom';
+    }
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const clampedLeft = Math.min(Math.max(centerX, 16), viewportWidth - 16);
+    popover.style.left = `${Math.round(clampedLeft)}px`;
+    popover.style.top = `${Math.round(top)}px`;
+    popover.dataset.placement = placement;
+  }
+
+  function closeInfoPopover({ focusTrigger = false } = {}) {
+    const trigger = infoPopoverState.trigger;
+    const popover = infoPopoverState.el;
+    if (popover) {
+      popover.removeAttribute('data-visible');
+      popover.setAttribute('aria-hidden', 'true');
+      popover.removeAttribute('data-placement');
+    }
+    if (trigger) {
+      trigger.setAttribute('aria-expanded', 'false');
+      trigger.removeAttribute('aria-controls');
+      if (focusTrigger && typeof trigger.focus === 'function') {
+        trigger.focus();
+      }
+    }
+    infoPopoverState.trigger = null;
+  }
+
+  function openInfoPopover(trigger) {
+    if (!trigger) return;
+    const content = getInfoContentFromTrigger(trigger);
+    if (!content) {
+      closeInfoPopover();
+      return;
+    }
+    const popover = ensureInfoPopoverElement();
+    popover.textContent = content;
+    popover.setAttribute('aria-hidden', 'false');
+    trigger.setAttribute('aria-expanded', 'true');
+    trigger.setAttribute('aria-controls', popover.id);
+    infoPopoverState.trigger = trigger;
+    positionInfoPopover(popover, trigger);
+    popover.dataset.visible = 'true';
+  }
+
+  function toggleInfoPopover(trigger) {
+    if (!trigger) return;
+    if (infoPopoverState.trigger === trigger) {
+      closeInfoPopover();
+    } else {
+      openInfoPopover(trigger);
+    }
+  }
+
+  function initializeInfoPopovers() {
+    const triggers = Array.from(document.querySelectorAll('[data-info-popup]'));
+    triggers.forEach(trigger => {
+      if (!trigger.hasAttribute('aria-haspopup')) {
+        trigger.setAttribute('aria-haspopup', 'dialog');
+      }
+      if (!trigger.hasAttribute('aria-expanded')) {
+        trigger.setAttribute('aria-expanded', 'false');
+      }
+    });
+    document.addEventListener('click', event => {
+      const trigger = event.target instanceof Element ? event.target.closest('[data-info-popup]') : null;
+      if (trigger) {
+        event.preventDefault();
+        toggleInfoPopover(trigger);
+        return;
+      }
+      const popover = infoPopoverState.el;
+      if (popover && event.target instanceof Element && popover.contains(event.target)) {
+        return;
+      }
+      closeInfoPopover();
+    });
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        closeInfoPopover({ focusTrigger: true });
+      }
+    });
+    window.addEventListener('resize', () => {
+      if (infoPopoverState.trigger) {
+        closeInfoPopover();
+      }
+    });
+    window.addEventListener('scroll', () => {
+      if (infoPopoverState.trigger) {
+        closeInfoPopover();
+      }
+    }, true);
+  }
+
+  initializeInfoPopovers();
 
   audioUI.panel = $('audioPanel');
   audioUI.body = $('audioPanelBody');
@@ -5247,6 +5389,7 @@ export function bootstrapApp() {
     sheetState.moved = false;
     sheetState.preventClick = false;
     panel.classList.remove('is-dragging');
+    closeInfoPopover();
     if (!isMobileSheetActive()) {
       sheetState.mode = 'compact';
       panel.removeAttribute('data-sheet-state');
@@ -5281,8 +5424,113 @@ export function bootstrapApp() {
       sheetState.moved = false;
       sheetState.preventClick = false;
       panel.classList.remove('is-dragging');
+      closeInfoPopover();
+      cancelPanelSwipe();
     }
     updateSheetHandleAria();
+  }
+
+  function navigatePanel(direction) {
+    if (!mobileSheetQuery.matches) return;
+    if (!panelVisible) return;
+    const currentIndex = mobilePanelOrder.indexOf(mobileActivePanel);
+    if (currentIndex === -1) return;
+    const nextIndex = currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= mobilePanelOrder.length) return;
+    const nextKey = mobilePanelOrder[nextIndex];
+    closeInfoPopover();
+    expandControlPanel(nextKey, { fromTab: true, preserveDesktop: true });
+  }
+
+  function cancelPanelSwipe() {
+    panelSwipeState.pointerId = null;
+    panelSwipeState.startX = 0;
+    panelSwipeState.startY = 0;
+    panelSwipeState.active = false;
+  }
+
+  function handlePanelSwipeStart(event) {
+    if (!panel || !mobileSheetQuery.matches || !panelVisible) {
+      return;
+    }
+    if (panelSwipeState.pointerId !== null || sheetState.pointerId !== null) {
+      return;
+    }
+    if (event.isPrimary === false) {
+      return;
+    }
+    const pointerType = typeof event.pointerType === 'string' ? event.pointerType : '';
+    if (pointerType && pointerType !== 'touch' && pointerType !== 'pen') {
+      return;
+    }
+    if (event.target && event.target.closest('.sheet-handle')) {
+      return;
+    }
+    if (event.target && event.target.closest('button, a, input, select, textarea, label, [role="slider"], [data-no-panel-swipe]')) {
+      return;
+    }
+    panelSwipeState.pointerId = event.pointerId;
+    panelSwipeState.startX = Number.isFinite(event.clientX) ? event.clientX : 0;
+    panelSwipeState.startY = Number.isFinite(event.clientY) ? event.clientY : 0;
+    panelSwipeState.active = false;
+  }
+
+  function handlePanelSwipeMove(event) {
+    if (panelSwipeState.pointerId === null || event.pointerId !== panelSwipeState.pointerId) {
+      return;
+    }
+    if (!mobileSheetQuery.matches) {
+      cancelPanelSwipe();
+      return;
+    }
+    const currentX = Number.isFinite(event.clientX) ? event.clientX : panelSwipeState.startX;
+    const currentY = Number.isFinite(event.clientY) ? event.clientY : panelSwipeState.startY;
+    const deltaX = currentX - panelSwipeState.startX;
+    const deltaY = currentY - panelSwipeState.startY;
+    if (!panelSwipeState.active) {
+      if (Math.abs(deltaY) > PANEL_SWIPE_VERTICAL_TOLERANCE_PX) {
+        cancelPanelSwipe();
+        return;
+      }
+      if (Math.abs(deltaX) > 18 && Math.abs(deltaX) > Math.abs(deltaY) * 1.2) {
+        panelSwipeState.active = true;
+      }
+    }
+    if (panelSwipeState.active) {
+      event.preventDefault();
+    }
+  }
+
+  function handlePanelSwipeEnd(event) {
+    if (panelSwipeState.pointerId === null || event.pointerId !== panelSwipeState.pointerId) {
+      return;
+    }
+    if (!mobileSheetQuery.matches) {
+      cancelPanelSwipe();
+      return;
+    }
+    const deltaX = Number.isFinite(event.clientX) ? event.clientX - panelSwipeState.startX : 0;
+    const deltaY = Number.isFinite(event.clientY) ? event.clientY - panelSwipeState.startY : 0;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+    if (panelSwipeState.active && absX >= PANEL_SWIPE_MIN_DISTANCE_PX && absX > absY) {
+      if (deltaX < 0) {
+        navigatePanel(1);
+      } else if (deltaX > 0) {
+        navigatePanel(-1);
+      }
+    }
+    cancelPanelSwipe();
+  }
+
+  function handlePanelSwipeCancel(event) {
+    if (panelSwipeState.pointerId === null) {
+      return;
+    }
+    if (event && panelSwipeState.pointerId !== event.pointerId) {
+      return;
+    }
+    cancelPanelSwipe();
   }
 
   function updateEditModeButton() {
@@ -5430,9 +5678,11 @@ export function bootstrapApp() {
     if (sheetState.pointerId === null || event.pointerId !== sheetState.pointerId) return;
     const delta = event.clientY - sheetState.startY;
     const maxOffset = getSheetCompactOffset();
+    const closeBuffer = Math.max(80, Math.round((viewportState.height || window.innerHeight || 0) * 0.12));
+    const limit = maxOffset + closeBuffer;
     let next = sheetState.startOffset + delta;
     if (!Number.isFinite(next)) next = 0;
-    next = Math.max(0, Math.min(maxOffset, next));
+    next = Math.max(0, Math.min(limit, next));
     if (Math.abs(delta) > 6) {
       sheetState.moved = true;
     }
@@ -5451,6 +5701,14 @@ export function bootstrapApp() {
     sheetState.pointerId = null;
     sheetState.moved = false;
     const maxOffset = getSheetCompactOffset();
+    const closeBuffer = Math.max(80, Math.round((viewportState.height || window.innerHeight || 0) * 0.12));
+    const closeTrigger = maxOffset + closeBuffer * 0.6;
+    if (lastOffset >= closeTrigger) {
+      sheetState.preventClick = true;
+      setSheetMode('compact', { force: true });
+      setPanelVisible(false);
+      return;
+    }
     if (moved) {
       const threshold = maxOffset * 0.45;
       const nextState = lastOffset > threshold ? 'compact' : 'expanded';
@@ -5818,7 +6076,14 @@ export function bootstrapApp() {
       if (delta <= DOUBLE_TAP_TIMEOUT_MS && distance <= DOUBLE_TAP_DISTANCE_PX) {
         resetDoubleTapState();
         doubleTapState.blockUntil = now + DOUBLE_TAP_TIMEOUT_MS;
-        await triggerDoubleTapAction();
+        if (!panelVisible) {
+          setPanelVisible(true);
+          if (isMobileSheetActive()) {
+            setSheetMode('compact', { force: true });
+          }
+        } else {
+          await triggerDoubleTapAction();
+        }
         return;
       }
     }
@@ -5840,6 +6105,13 @@ export function bootstrapApp() {
     }
     resetDoubleTapState();
     doubleTapState.blockUntil = now + DOUBLE_TAP_TIMEOUT_MS;
+    if (!panelVisible) {
+      setPanelVisible(true);
+      if (isMobileSheetActive()) {
+        setSheetMode('compact', { force: true });
+      }
+      return;
+    }
     await triggerDoubleTapAction();
   }
 
@@ -6518,6 +6790,10 @@ export function bootstrapApp() {
     });
   }
 
+  panel.addEventListener('pointerdown', handlePanelSwipeStart);
+  panel.addEventListener('pointermove', handlePanelSwipeMove);
+  panel.addEventListener('pointerup', handlePanelSwipeEnd);
+  panel.addEventListener('pointercancel', handlePanelSwipeCancel);
   panel.addEventListener('pointermove', handleSheetDragMove);
   panel.addEventListener('pointerup', finishSheetDrag);
   panel.addEventListener('pointercancel', finishSheetDrag);

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,6 +62,89 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+.sr-only,
+.info-source {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.info-badge {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.info-badge:hover,
+.info-badge:focus-visible {
+  background: rgba(79, 140, 255, 0.24);
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.info-badge--inline {
+  margin-left: 0.4rem;
+}
+
+.info-badge--block {
+  display: inline-flex;
+  margin-top: 0.5rem;
+}
+
+.info-popover {
+  position: fixed;
+  z-index: 60;
+  max-width: min(22rem, calc(100vw - 2rem));
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(6, 12, 20, 0.94);
+  color: var(--color-text-primary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.25rem);
+  transition:
+    opacity 0.18s ease,
+    transform 0.2s ease;
+}
+
+.info-popover[data-visible='true'] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -0.35rem);
+}
+
+.info-popover[data-placement='bottom'] {
+  transform: translate(-50%, 0.3rem);
+}
+
+.info-popover[data-placement='bottom'][data-visible='true'] {
+  transform: translate(-50%, 0.6rem);
+}
+
 @media (min-width: 64rem) {
   body {
     font-size: var(--font-size-desktop);
@@ -183,6 +266,17 @@ body {
   gap: 0.85rem;
 }
 
+.panel-card__header > div {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.panel-card__header > div .info-badge {
+  margin-top: 0.1rem;
+}
+
 .panel-card__subtitle {
   margin: 0.15rem 0 0;
   font-size: 0.85rem;
@@ -237,39 +331,48 @@ body {
   );
   backdrop-filter: blur(10px);
   padding-bottom: var(--spacing-s);
+  justify-items: center;
 }
 
 .control-panel-tab {
   appearance: none;
-  border: 1px solid var(--color-border);
+  border: none;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  color: inherit;
-  font-size: 0.85rem;
-  letter-spacing: 0.01em;
+  background: transparent;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
-  padding: 0.5rem 0.6rem;
+  padding: 0.45rem;
+  transition: transform 0.2s ease;
+}
+
+.control-panel-tab__dot {
+  width: 0.66rem;
+  height: 0.66rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 0 0 0 rgba(79, 140, 255, 0.2);
   transition:
-    border-color 0.2s ease,
     background 0.2s ease,
+    box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 
-.control-panel-tab.is-active,
-.control-panel-tab[aria-pressed='true'] {
-  border-color: var(--color-primary);
-  background: rgba(79, 140, 255, 0.22);
-  transform: translateY(-1px);
+.control-panel-tab.is-active .control-panel-tab__dot,
+.control-panel-tab[aria-pressed='true'] .control-panel-tab__dot {
+  background: var(--color-primary);
+  transform: scale(1.1);
+  box-shadow: 0 0 0 6px rgba(79, 140, 255, 0.22);
 }
 
-.control-panel-tab:hover,
+.control-panel-tab:hover .control-panel-tab__dot,
+.control-panel-tab:focus-visible .control-panel-tab__dot {
+  background: rgba(79, 140, 255, 0.6);
+  box-shadow: 0 0 0 6px rgba(79, 140, 255, 0.18);
+}
+
 .control-panel-tab:focus-visible {
-  border-color: var(--color-primary);
-  background: rgba(79, 140, 255, 0.3);
   outline: none;
 }
 
@@ -291,6 +394,17 @@ body {
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+}
+
+.control-panel__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.control-panel__title .info-badge {
+  margin-top: 0.1rem;
 }
 
 .control-panel__title h2 {
@@ -1434,6 +1548,21 @@ select {
   #panel {
     width: min(var(--container-desktop, 75rem), calc(100% - 2 * var(--spacing-xxl)));
     padding: var(--spacing-xl) var(--spacing-xxl);
+  }
+}
+
+@media (max-width: 48rem) {
+  .control-panel.is-collapsed {
+    display: none;
+  }
+
+  .control-panel:not(.is-collapsed) {
+    display: flex;
+  }
+
+  .info-badge--block {
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 canvas {


### PR DESCRIPTION
## Summary
- replace the panel tab labels with dot indicators and add info buttons that surface contextual help for each section
- add swipe navigation, popover handling, and drag-to-close behaviour to the mobile control panel, including double-tap reopen logic
- update styles to support the new UI elements and hide inactive panels on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e54a6d6c408324bc0adac0179ee056