### PR TITLE
Fix bottom sheet navigation overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,21 +8,25 @@
 </head>
 <body>
 <div id="panel" class="is-hidden" aria-hidden="true">
-  <div class="sheet-handle">
-    <button id="sheetHandle" type="button" aria-expanded="false" aria-controls="panel">
-      <span class="sheet-handle-bar" aria-hidden="true"></span>
-      <span class="sheet-handle-label">Panel vergrößern</span>
-    </button>
-  </div>
-  <header class="panel-header">
-    <div class="panel-header__title">
-      <h1 class="panel-header__heading">Steuerzentrale</h1>
-      <p class="panel-header__subtitle">Passe Audio, Presets und Parameter im kompakten Layout an.</p>
-    </div>
-    <button id="panelClose" type="button" class="panel-header__close" data-no-swipe aria-label="Panel schließen" aria-controls="panel">
-      <span aria-hidden="true">✕</span>
-    </button>
-  </header>
+  <div
+    id="sheetHandle"
+    class="sheet-handle"
+    role="button"
+    aria-controls="panel"
+    aria-label="Panel vergrößern"
+    aria-expanded="false"
+    tabindex="0"
+  ></div>
+  <button
+    id="panelClose"
+    type="button"
+    class="panel-close"
+    data-no-swipe
+    aria-label="Panel schließen"
+    aria-controls="panel"
+  >
+    <span aria-hidden="true">✕</span>
+  </button>
   <nav class="control-panel-tabs bottom-nav" aria-label="Panel-Navigation">
     <button
       type="button"
@@ -214,7 +218,7 @@
             <button type="button" class="panel-card__action" id="presetRandomPlayback" aria-pressed="false" disabled>🎲 Shuffle</button>
           </div>
         </header>
-        <div class="preset-gallery" id="userPresetGallery" role="list" aria-label="Eigene Presets"></div>
+        <div class="preset-gallery gallery-grid" id="userPresetGallery" role="list" aria-label="Eigene Presets"></div>
         <p class="preset-gallery__empty" id="userPresetEmpty">Noch keine Presets gespeichert. Erstelle im Config-Panel deine ersten Favoriten.</p>
       </section>
     </div>

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -732,12 +732,12 @@ export function bootstrapApp() {
     userPresetState.items.forEach(preset => {
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'preset-card';
+      button.className = 'preset-card gallery-card';
       button.dataset.presetId = preset.id;
       button.setAttribute('aria-pressed', userPresetState.selected.has(preset.id) ? 'true' : 'false');
       const preview = computePresetPreview(preset.params);
       const thumb = document.createElement('div');
-      thumb.className = 'preset-card__thumb';
+      thumb.className = 'preset-card__thumb gallery-card__media';
       thumb.style.background = preview.gradient;
       button.appendChild(thumb);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,7 +30,7 @@
   --sheet-expanded-height: 84vh;
   --app-viewport-height: 100vh;
   --panel-max-height: 84vh;
-  --bottom-nav-height: 64px;
+  --bottom-nav-height: 72px;
   --nav-max-width: 28rem;
   color-scheme: dark;
 }
@@ -357,7 +357,10 @@ button {
   line-height: 1.4;
 }
 
-.panel-header__close {
+.panel-close {
+  position: absolute;
+  top: var(--spacing-s);
+  right: var(--spacing-s);
   appearance: none;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(35, 40, 50, 0.65);
@@ -377,10 +380,11 @@ button {
     transform 0.2s ease,
     box-shadow 0.2s ease;
   touch-action: manipulation;
+  z-index: 110;
 }
 
-.panel-header__close:hover,
-.panel-header__close:focus-visible {
+.panel-close:hover,
+.panel-close:focus-visible {
   background: rgba(93, 141, 255, 0.24);
   border-color: rgba(93, 141, 255, 0.52);
   transform: translateY(-1px);
@@ -388,23 +392,59 @@ button {
   box-shadow: 0 0 0 3px rgba(93, 141, 255, 0.24);
 }
 
-.panel-header__close:active {
+.panel-close:active {
   transform: translateY(0);
 }
 
 .control-panel-tabs {
   order: 2;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   margin: 0;
-  padding: 0.75rem 0.5rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
-  border-radius: var(--radius-s);
-  background: rgba(35, 40, 50, 0.68);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-  position: sticky;
+  padding: 0;
+  list-style: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.bottom-nav {
+  position: fixed;
   bottom: 0;
-  z-index: 3;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(100%, calc(100% - 2 * var(--spacing-m)));
+  max-width: var(--panel-max-width, 34rem);
+  height: var(--bottom-nav-height);
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1rem;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  box-sizing: border-box;
+  background: rgba(20, 22, 26, 0.85);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-s) var(--radius-s) 0 0;
+  box-shadow: 0 -10px 32px rgba(5, 7, 12, 0.28);
+  z-index: 100;
+}
+
+.bottom-nav .control-panel-tab {
+  flex: 1 1 0;
+}
+
+.main-content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px) + 1rem);
+}
+
+.main-content > *:last-child {
+  margin-bottom: 1.5rem;
 }
 
 .panel-launcher {
@@ -849,18 +889,20 @@ button {
   margin: 0;
 }
 
+
 .preset-gallery {
   display: grid;
-  gap: 0.65rem;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
 }
 
+.preset-gallery.gallery-grid,
 .preset-gallery[data-mode='grid'] {
-  grid-auto-rows: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .preset-gallery[data-mode='list'] {
   grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
 }
 
 .preset-gallery[data-mode='list'] .preset-card {
@@ -923,12 +965,13 @@ button {
   box-shadow: inset 0 0 0 1px rgba(93, 141, 255, 0.4);
 }
 
+
+.gallery-card__media,
 .preset-card__thumb {
   width: 100%;
-  aspect-ratio: 4 / 3;
-  max-height: 120px;
-  border-radius: 0.5rem;
-  background: linear-gradient(135deg, rgba(90, 190, 255, 0.6), rgba(160, 90, 255, 0.6));
+  aspect-ratio: 1 / 1;
+  border-radius: 10px;
+  background: #1b1f24;
   position: relative;
   overflow: hidden;
   display: flex;
@@ -936,6 +979,16 @@ button {
   justify-content: center;
 }
 
+.gallery-card__media img,
+.preset-card__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-card__media canvas,
+.gallery-card__media svg,
 .preset-card__thumb canvas,
 .preset-card__thumb svg {
   width: 100%;
@@ -1934,48 +1987,17 @@ select {
   opacity: 1;
 }
 .sheet-handle {
-  display: flex;
-  justify-content: center;
-  margin: calc(-1 * var(--spacing-s)) auto var(--spacing-s);
-}
-.sheet-handle button {
-  appearance: none;
-  border: none;
-  background: transparent;
-  padding: var(--spacing-s) var(--spacing-l);
-  border-radius: var(--radius-l);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-s);
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.25);
+  margin: 0.5rem auto 0.75rem;
   cursor: grab;
   touch-action: none;
-  color: inherit;
 }
-.sheet-handle button:active {
+
+.sheet-handle:active {
   cursor: grabbing;
-}
-.sheet-handle-bar {
-  width: 46px;
-  height: 5px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.35);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-}
-.sheet-handle button:focus-visible .sheet-handle-bar {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 4px;
-}
-.sheet-handle-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 .preset-studio__actions {
   display: flex;


### PR DESCRIPTION
## Summary
- replace the bulky panel header with a compact drag handle and reposition the close control
- make the bottom navigation bar fixed with matching content padding so presets never scroll underneath it
- square up the gallery card previews for consistent thumbnails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e634d3109c8324999d5c361e7c6559