### PR TITLE
Add Docker container setup and deployment guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+Dockerfile
+.dockerignore
+docker-compose.yml
+AGENTS.md
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:1.27-alpine
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+WORKDIR /usr/share/nginx/html
+
+COPY index.html ./
+COPY three.min.js OrbitControls.js STLLoader.js ./
+COPY Musik ./Musik
+COPY docs ./docs
+COPY scripts ./scripts
+
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -13,3 +13,103 @@ node scripts/generate-preset-playlist.mjs
 ```
 
 Das Skript erstellt bzw. aktualisiert `Musik/playlist.json` und ermittelt Dateigröße sowie MIME-Typ. Anschließend stehen die Titel bei der nächsten Aktualisierung der Seite direkt in der App bereit.
+
+## Container-Setup
+
+### Überblick
+
+- Die App ist ein statisches Frontend und wird im Container von `nginx:alpine` ausgeliefert.
+- Die Dateien aus diesem Repository werden unter `/usr/share/nginx/html` bereitgestellt.
+- Der Server ist vorkonfiguriert für Audio-Streaming (Range Requests), gzip-Komprimierung und lange Cache-Header für statische Assets.
+
+### Voraussetzungen
+
+- Docker und Docker Compose Plugin
+- Optional: Node.js (nur nötig, wenn du `Musik/playlist.json` vor dem Build mit dem Playlist-Skript aktualisieren möchtest)
+
+### Schnelles Starten mit Docker Compose (lokal)
+
+1. Optional Playlist aktualisieren:
+   ```bash
+   node scripts/generate-preset-playlist.mjs
+   ```
+2. Container bauen:
+   ```bash
+   docker compose build
+   ```
+3. Container starten (Standard-Port 8080 → Container-Port 80):
+   ```bash
+   MUSIC_HTTP_PORT=8080 docker compose up -d
+   ```
+4. Verfügbarkeit prüfen:
+   ```bash
+   curl -I http://localhost:8080
+   ```
+
+## Deployment auf Debian (music.rtfx.fyi)
+
+### 1) System vorbereiten
+
+```bash
+sudo apt update
+sudo apt install -y ca-certificates curl gnupg ufw docker.io docker-compose-plugin
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER # danach neu einloggen
+```
+
+### 2) Firewall und Ports
+
+```bash
+sudo ufw allow 22/tcp   # SSH
+sudo ufw allow 80/tcp   # HTTP
+sudo ufw allow 443/tcp  # HTTPS (für TLS oder Reverse Proxy)
+sudo ufw enable
+sudo ufw status
+```
+
+### 3) DNS-Records für music.rtfx.fyi
+
+- Lege einen **A-Record** für `music.rtfx.fyi` auf die öffentliche IPv4-Adresse des Servers.
+- Optional: Lege zusätzlich einen **AAAA-Record** auf die IPv6-Adresse an.
+- Typische TTL: 300–600 Sekunden; überprüfe die Propagierung mit `dig music.rtfx.fyi`.
+
+### 4) Quellcode holen und Playlist pflegen
+
+```bash
+cd /opt
+sudo git clone https://github.com/cognifex/OrderlyChaos.git
+cd OrderlyChaos
+# Optional: Playlist neu erzeugen, wenn du neue Titel abgelegt hast
+node scripts/generate-preset-playlist.mjs
+```
+
+### 5) Container bauen und starten
+
+```bash
+# Für den Produktivbetrieb Port 80 auf dem Host nutzen
+export MUSIC_HTTP_PORT=80
+sudo docker compose build
+sudo docker compose up -d
+sudo docker compose ps
+```
+
+### 6) HTTPS/Reverse Proxy (empfohlen)
+
+- Setze vor den Container einen Reverse Proxy (z. B. Caddy, Traefik oder Nginx) auf demselben Host.
+- Beispiel Caddyfile (Container hört auf Port 80):
+  ```
+  music.rtfx.fyi {
+    reverse_proxy 127.0.0.1:80
+  }
+  ```
+- Starte den Proxy getrennt (eigenes Compose-Setup oder nativer Dienst), sodass er Ports 80/443 bedient und automatisch TLS-Zertifikate via Let's Encrypt verwaltet.
+
+### 7) Betrieb und Wartung
+
+```bash
+sudo docker compose logs -f
+sudo docker compose pull && sudo docker compose build && sudo docker compose up -d
+sudo docker compose down  # Container stoppen, Daten bleiben erhalten
+```
+
+Nach erfolgreichem Start solltest du die Seite über `http://music.rtfx.fyi` bzw. `https://music.rtfx.fyi` (mit Proxy) erreichen.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  music-app:
+    build: .
+    image: music-rtfx-fyi:latest
+    ports:
+      - "${MUSIC_HTTP_PORT:-8080}:80"
+    restart: unless-stopped

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,41 @@
+server {
+    listen 80;
+    server_name music.rtfx.fyi _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log warn;
+
+    sendfile on;
+
+    gzip on;
+    gzip_min_length 512;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        application/xml
+        application/xml+rss
+        text/javascript
+        application/wasm
+        audio/mpeg
+        audio/wav
+        audio/ogg;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|webp|mp3|wav|ogg|json)$ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx-based Dockerfile and compose service to serve the static app
- add dockerignore to keep the image lean
- document container usage and Debian deployment for music.rtfx.fyi, including DNS, firewall, and reverse proxy guidance

## Testing
- Not run (Docker not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f50eb523c83229903c98c4e376eed)